### PR TITLE
For SonarQube allow token based auth

### DIFF
--- a/collectors/build/sonar/src/main/java/com/capitalone/dashboard/collector/DefaultSonar6Client.java
+++ b/collectors/build/sonar/src/main/java/com/capitalone/dashboard/collector/DefaultSonar6Client.java
@@ -364,9 +364,8 @@ public class DefaultSonar6Client implements SonarClient {
 
     private HttpHeaders createHeaders(String username, String password){
         HttpHeaders headers = new HttpHeaders();
-        if (username != null && !username.isEmpty() &&
-                password != null && !password.isEmpty()) {
-            String auth = username + ":" + password;
+        if (username != null && !username.isEmpty()) {
+            String auth = username + ":" + password == null ? '' : password;
             byte[] encodedAuth = Base64.encodeBase64(
                     auth.getBytes(Charset.forName("US-ASCII"))
             );

--- a/collectors/build/sonar/src/main/java/com/capitalone/dashboard/collector/DefaultSonarClient.java
+++ b/collectors/build/sonar/src/main/java/com/capitalone/dashboard/collector/DefaultSonarClient.java
@@ -246,9 +246,8 @@ public class DefaultSonarClient implements SonarClient {
 
     private final HttpHeaders createHeaders(String username, String password){
         HttpHeaders headers = new HttpHeaders();
-        if (username != null && !username.isEmpty() &&
-            password != null && !password.isEmpty()) {
-          String auth = username + ":" + password;
+        if (username != null && !username.isEmpty()) {
+          String auth = username + ":" + password == null ? '': password;
           byte[] encodedAuth = Base64.encodeBase64(
               auth.getBytes(Charset.forName("US-ASCII"))
           );


### PR DESCRIPTION
Per the docs for SonarQube at https://docs.sonarqube.org/display/DEV/Web+API when using token based authentication then the token goes into the username part, followed by a colon and empty password.

The current code base does not allow a null password, it is expecting both a username and password, this PR corrects that.

See https://docs.sonarqube.org/display/DEV/Web+API