### PR TITLE
Backward compatibility for POST endpoints. Jenkins plugin update: 

### DIFF
--- a/api/src/main/java/com/capitalone/dashboard/config/WebSecurityConfig.java
+++ b/api/src/main/java/com/capitalone/dashboard/config/WebSecurityConfig.java
@@ -66,10 +66,14 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
                 //TODO: Secure with API Key
                 .antMatchers(HttpMethod.POST, "/build").permitAll()
                 .antMatchers(HttpMethod.POST, "/deploy").permitAll()
+                .antMatchers(HttpMethod.POST, "/v2/build").permitAll()
+                .antMatchers(HttpMethod.POST, "/v2/deploy").permitAll()
                 .antMatchers(HttpMethod.POST, "/performance").permitAll()
                 .antMatchers(HttpMethod.POST, "/artifact").permitAll()
                 .antMatchers(HttpMethod.POST, "/quality/test").permitAll()
                 .antMatchers(HttpMethod.POST, "/quality/static-analysis").permitAll()
+                .antMatchers(HttpMethod.POST, "/v2/quality/test").permitAll()
+                .antMatchers(HttpMethod.POST, "/v2/quality/static-analysis").permitAll()
                 .antMatchers(HttpMethod.POST, "/generic-item").permitAll()
                 //Temporary solution to allow Github webhook
                 .antMatchers(HttpMethod.POST, "/commit/github/v3").permitAll()

--- a/api/src/main/java/com/capitalone/dashboard/rest/BuildController.java
+++ b/api/src/main/java/com/capitalone/dashboard/rest/BuildController.java
@@ -51,4 +51,13 @@ public class BuildController {
                 .status(HttpStatus.CREATED)
                 .body(response);
     }
+
+    @RequestMapping(value = "/v2/build", method = POST,
+            consumes = APPLICATION_JSON_VALUE, produces = APPLICATION_JSON_VALUE)
+    public ResponseEntity<String> createBuildv2(@Valid @RequestBody BuildDataCreateRequest request) throws HygieiaException {
+        String response = buildService.createV2(request);
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(response);
+    }
 }

--- a/api/src/main/java/com/capitalone/dashboard/rest/CodeQualityController.java
+++ b/api/src/main/java/com/capitalone/dashboard/rest/CodeQualityController.java
@@ -58,6 +58,15 @@ public class CodeQualityController {
                 .body(response);
     }
 
+    @RequestMapping(value = "/v2/quality/static-analysis", method = POST,
+            consumes = APPLICATION_JSON_VALUE, produces = APPLICATION_JSON_VALUE)
+    public ResponseEntity<String> createStaticAnanlysisV2(@Valid @RequestBody CodeQualityCreateRequest request) throws HygieiaException {
+        String response = codeQualityService.createV2(request);
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(response);
+    }
+
     @RequestMapping(value = "/quality/security-analysis", method = GET, produces = APPLICATION_JSON_VALUE)
     public DataResponse<Iterable<CodeQuality>> qualitySecurityAnalysis(@Valid CodeQualityRequest request) {
         request.setType(CodeQualityType.SecurityAnalysis);

--- a/api/src/main/java/com/capitalone/dashboard/rest/DeployController.java
+++ b/api/src/main/java/com/capitalone/dashboard/rest/DeployController.java
@@ -56,13 +56,22 @@ public class DeployController {
 
     @RequestMapping(value = "/deploy", method = POST,
             consumes = APPLICATION_JSON_VALUE, produces = APPLICATION_JSON_VALUE)
-    public ResponseEntity<String> createBuild(@Valid @RequestBody DeployDataCreateRequest request) throws HygieiaException {
+    public ResponseEntity<String> createDeploy(@Valid @RequestBody DeployDataCreateRequest request) throws HygieiaException {
         String response = deployService.create(request);
         return ResponseEntity
                 .status(HttpStatus.CREATED)
                 .body(response);
     }
-    
+
+    @RequestMapping(value = "/v2/deploy", method = POST,
+            consumes = APPLICATION_JSON_VALUE, produces = APPLICATION_JSON_VALUE)
+    public ResponseEntity<String> createDeployV2(@Valid @RequestBody DeployDataCreateRequest request) throws HygieiaException {
+        String response = deployService.createV2(request);
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(response);
+    }
+
     @RequestMapping(value = "/deploy/rundeck", method = POST,
             consumes = TEXT_XML_VALUE, produces = APPLICATION_JSON_VALUE)
     public ResponseEntity<String> createRundeckBuild(HttpServletRequest request,
@@ -81,4 +90,24 @@ public class DeployController {
                 .status(HttpStatus.CREATED)
                 .body(response);        
     }
+
+    @RequestMapping(value = "/v2/deploy/rundeck", method = POST,
+            consumes = TEXT_XML_VALUE, produces = APPLICATION_JSON_VALUE)
+    public ResponseEntity<String> createRundeckBuildV2(HttpServletRequest request,
+                                                     @RequestHeader("X-Rundeck-Notification-Execution-ID") String executionId,
+                                                     @RequestHeader("X-Rundeck-Notification-Trigger") String status) throws HygieiaException{
+        Document doc = null;
+        try {
+            DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+            DocumentBuilder builder = factory.newDocumentBuilder();
+            doc = builder.parse(new InputSource(request.getInputStream()));
+        } catch (ParserConfigurationException | SAXException | IOException e) {
+            throw new HygieiaException(e);
+        }
+        String response = deployService.createRundeckBuildV2(doc, request.getParameterMap(), executionId, status);
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(response);
+    }
+
 }

--- a/api/src/main/java/com/capitalone/dashboard/rest/TestResultController.java
+++ b/api/src/main/java/com/capitalone/dashboard/rest/TestResultController.java
@@ -53,6 +53,15 @@ public class TestResultController {
                     .body(response);
     }
 
+    @RequestMapping(value = "/v2/quality/test", method = POST,
+            consumes = APPLICATION_JSON_VALUE, produces = APPLICATION_JSON_VALUE)
+    public ResponseEntity<String> createTestV2(@Valid @RequestBody TestDataCreateRequest request) throws HygieiaException {
+        String response = testResultService.createV2(request);
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(response);
+    }
+
     @RequestMapping(value = "/quality/testresult", method = POST,
             consumes = APPLICATION_JSON_VALUE, produces = APPLICATION_JSON_VALUE)
     public ResponseEntity<String> createPerfTest(@Valid @RequestBody PerfTestDataCreateRequest request) throws HygieiaException {
@@ -61,4 +70,14 @@ public class TestResultController {
                 .status(HttpStatus.CREATED)
                 .body(response);
     }
+
+    @RequestMapping(value = "/v2/quality/testresult", method = POST,
+            consumes = APPLICATION_JSON_VALUE, produces = APPLICATION_JSON_VALUE)
+    public ResponseEntity<String> createPerfTestV2(@Valid @RequestBody PerfTestDataCreateRequest request) throws HygieiaException {
+        String response = testResultService.createPerfV2(request);
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(response);
+    }
+
 }

--- a/api/src/main/java/com/capitalone/dashboard/service/BuildService.java
+++ b/api/src/main/java/com/capitalone/dashboard/service/BuildService.java
@@ -17,4 +17,5 @@ public interface BuildService {
     DataResponse<Iterable<Build>> search(BuildSearchRequest request);
 
     String create(BuildDataCreateRequest request) throws HygieiaException;
+    String createV2(BuildDataCreateRequest request) throws HygieiaException;
 }

--- a/api/src/main/java/com/capitalone/dashboard/service/BuildServiceImpl.java
+++ b/api/src/main/java/com/capitalone/dashboard/service/BuildServiceImpl.java
@@ -84,8 +84,7 @@ public class BuildServiceImpl implements BuildService {
         return new DataResponse<>(result, collector.getLastExecuted());
     }
 
-    @Override
-    public String create(BuildDataCreateRequest request) throws HygieiaException {
+    protected Build createBuild(BuildDataCreateRequest request) throws HygieiaException {
         /**
          * Step 1: create Collector if not there
          * Step 2: create Collector item if not there
@@ -109,8 +108,20 @@ public class BuildServiceImpl implements BuildService {
             throw new HygieiaException("Failed inserting/updating build information.", HygieiaException.ERROR_INSERTING_DATA);
         }
 
-        return String.format("%s,%s", build.getId().toString(), build.getCollectorItemId().toString());
+        return build;
 
+    }
+
+    @Override
+    public String create(BuildDataCreateRequest request) throws HygieiaException {
+        Build build = createBuild(request);
+        return build.getId().toString();
+    }
+
+    @Override
+    public String createV2(BuildDataCreateRequest request) throws HygieiaException {
+        Build build = createBuild(request);
+        return String.format("%s,%s", build.getId().toString(), build.getCollectorItemId().toString());
     }
 
     private Collector createCollector() {

--- a/api/src/main/java/com/capitalone/dashboard/service/CodeQualityService.java
+++ b/api/src/main/java/com/capitalone/dashboard/service/CodeQualityService.java
@@ -16,4 +16,5 @@ public interface CodeQualityService {
      */
     DataResponse<Iterable<CodeQuality>> search(CodeQualityRequest request);
     String create(CodeQualityCreateRequest request) throws HygieiaException;
+    String createV2(CodeQualityCreateRequest request) throws HygieiaException;
 }

--- a/api/src/main/java/com/capitalone/dashboard/service/CodeQualityServiceImpl.java
+++ b/api/src/main/java/com/capitalone/dashboard/service/CodeQualityServiceImpl.java
@@ -123,8 +123,7 @@ public class CodeQualityServiceImpl implements CodeQualityService {
     }
 
 
-    @Override
-    public String create(CodeQualityCreateRequest request) throws HygieiaException {
+    protected CodeQuality createCodeQuality(CodeQualityCreateRequest request) throws HygieiaException {
         /*
           Step 1: create Collector if not there
           Step 2: create Collector item if not there
@@ -145,13 +144,25 @@ public class CodeQualityServiceImpl implements CodeQualityService {
         CodeQuality quality = createCodeQuality(collectorItem, request);
 
         if (quality == null) {
-            throw new HygieiaException("Failed inserting/updating Quality information.", HygieiaException.ERROR_INSERTING_DATA);
+            throw new HygieiaException("Failed inserting/updating Code Quality information.", HygieiaException.ERROR_INSERTING_DATA);
         }
 
-        return quality.getId().toString() + "," + quality.getCollectorItemId().toString();
+        return quality;
 
     }
 
+    @Override
+    public String create(CodeQualityCreateRequest request) throws HygieiaException {
+        CodeQuality quality = createCodeQuality(request);
+        return quality.getId().toString();
+    }
+
+    @Override
+    public String createV2(CodeQualityCreateRequest request) throws HygieiaException {
+        CodeQuality quality = createCodeQuality(request);
+        return quality.getId().toString() + "," + quality.getCollectorItemId().toString();
+
+    }
 
     private Collector createCollector() {
         CollectorRequest collectorReq = new CollectorRequest();

--- a/api/src/main/java/com/capitalone/dashboard/service/DeployService.java
+++ b/api/src/main/java/com/capitalone/dashboard/service/DeployService.java
@@ -22,8 +22,10 @@ public interface DeployService {
     DataResponse<List<Environment>> getDeployStatus(ObjectId componentId);
 
     String create(DeployDataCreateRequest request) throws HygieiaException;
+    String createV2(DeployDataCreateRequest request) throws HygieiaException;
 
     DataResponse<List<Environment>> getDeployStatus(String applicationName);
 
     String createRundeckBuild(Document doc, Map<String, String[]> parameters, String executionId, String status) throws HygieiaException;
+    String createRundeckBuildV2(Document doc, Map<String, String[]> parameters, String executionId, String status) throws HygieiaException;
 }

--- a/api/src/main/java/com/capitalone/dashboard/service/TestResultService.java
+++ b/api/src/main/java/com/capitalone/dashboard/service/TestResultService.java
@@ -11,5 +11,7 @@ public interface TestResultService {
 
     DataResponse<Iterable<TestResult>> search(TestResultRequest request);
     String create(TestDataCreateRequest request) throws HygieiaException;
+    String createV2(TestDataCreateRequest request) throws HygieiaException;
     String createPerf(PerfTestDataCreateRequest request) throws HygieiaException;
+    String createPerfV2(PerfTestDataCreateRequest request) throws HygieiaException;
 }

--- a/api/src/main/java/com/capitalone/dashboard/service/TestResultServiceImpl.java
+++ b/api/src/main/java/com/capitalone/dashboard/service/TestResultServiceImpl.java
@@ -1,7 +1,13 @@
 package com.capitalone.dashboard.service;
 
 import com.capitalone.dashboard.misc.HygieiaException;
-import com.capitalone.dashboard.model.*;
+import com.capitalone.dashboard.model.Collector;
+import com.capitalone.dashboard.model.CollectorItem;
+import com.capitalone.dashboard.model.CollectorType;
+import com.capitalone.dashboard.model.Component;
+import com.capitalone.dashboard.model.DataResponse;
+import com.capitalone.dashboard.model.QTestResult;
+import com.capitalone.dashboard.model.TestResult;
 import com.capitalone.dashboard.repository.CollectorRepository;
 import com.capitalone.dashboard.repository.ComponentRepository;
 import com.capitalone.dashboard.repository.TestResultRepository;
@@ -12,7 +18,6 @@ import com.capitalone.dashboard.request.TestResultRequest;
 import com.google.common.collect.Lists;
 import com.mysema.query.BooleanBuilder;
 import org.apache.commons.lang.StringUtils;
-import org.bouncycastle.util.test.Test;
 import org.bson.types.ObjectId;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.PageRequest;
@@ -148,8 +153,8 @@ public class TestResultServiceImpl implements TestResultService {
         return results;
     }
 
-    @Override
-    public String create(TestDataCreateRequest request) throws HygieiaException {
+
+    protected TestResult createTest(TestDataCreateRequest request) throws HygieiaException {
         /*
           Step 1: create Collector if not there
           Step 2: create Collector item if not there
@@ -175,11 +180,25 @@ public class TestResultServiceImpl implements TestResultService {
             throw new HygieiaException("Failed inserting/updating Test information.", HygieiaException.ERROR_INSERTING_DATA);
         }
 
-        return testResult.getId().toString() + "," + testResult.getCollectorItemId().toString();
+        return testResult;
 
     }
 
-    public String createPerf(PerfTestDataCreateRequest request) throws HygieiaException {
+    @Override
+    public String create(TestDataCreateRequest request) throws HygieiaException {
+        TestResult testResult = createTest(request);
+        return testResult.getId().toString();
+    }
+
+    @Override
+    public String createV2(TestDataCreateRequest request) throws HygieiaException {
+        TestResult testResult = createTest(request);
+        return testResult.getId().toString() + "," + testResult.getCollectorItemId().toString();
+    }
+
+
+
+    protected TestResult createPerfTest(PerfTestDataCreateRequest request) throws HygieiaException {
         /**
          * Step 1: create performance Collector if not there
          * Step 2: create Perfomance Collector item if not there
@@ -197,8 +216,20 @@ public class TestResultServiceImpl implements TestResultService {
         if (testResult == null) {
             throw new HygieiaException("Failed inserting/updating Test information.", HygieiaException.ERROR_INSERTING_DATA);
         }
-        return testResult.getId().toString() + "," + testResult.getCollectorItemId().toString();
+        return testResult;
 
+    }
+
+    @Override
+    public String createPerf(PerfTestDataCreateRequest request) throws HygieiaException {
+        TestResult testResult = createPerfTest(request);
+        return testResult.getId().toString();
+    }
+
+    @Override
+    public String createPerfV2(PerfTestDataCreateRequest request) throws HygieiaException {
+        TestResult testResult = createPerfTest(request);
+        return testResult.getId().toString() + "," + testResult.getCollectorItemId().toString();
     }
 
     private Collector createCollector() {

--- a/api/src/test/java/com/capitalone/dashboard/rest/DeployControllerTest.java
+++ b/api/src/test/java/com/capitalone/dashboard/rest/DeployControllerTest.java
@@ -12,6 +12,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import org.bson.types.ObjectId;
@@ -64,11 +65,11 @@ public class DeployControllerTest {
         component.setAsOfDate(100L);
 
         Server server = new Server("server name", false);
-        DeployableUnit unit = new DeployableUnit(component, Arrays.asList(server));
+        DeployableUnit unit = new DeployableUnit(component, Collections.singletonList(server));
 
         Environment e = new Environment("QA", "http://www.google.com");
         e.getUnits().add(unit);
-        DataResponse<List<Environment>> response = new DataResponse<>(Arrays.asList(e), 1);
+        DataResponse<List<Environment>> response = new DataResponse<>(Collections.singletonList(e), 1);
 
         when(deployService.getDeployStatus(componentId)).thenReturn(response);
 
@@ -108,4 +109,18 @@ public class DeployControllerTest {
             .andExpect(status().isCreated())
             .andExpect(content().contentType(MediaType.APPLICATION_JSON));        
     }
+
+    @Test
+    public void rundeckPostEndpointParsesXmlIntoDocumentV2() throws Exception {
+        when(deployService.createRundeckBuildV2(any(Document.class), any(), eq("test"), eq("success")))
+                .thenReturn("8675309");
+        mockMvc.perform(post("/v2/deploy/rundeck")
+                .content("<valid></valid>")
+                .contentType(MediaType.TEXT_XML_VALUE)
+                .header("X-Rundeck-Notification-Execution-ID", "test")
+                .header("X-Rundeck-Notification-Trigger", "success"))
+                .andExpect(status().isCreated())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON));
+    }
+
 }

--- a/api/src/test/java/com/capitalone/dashboard/service/CodeQualityServiceTest.java
+++ b/api/src/test/java/com/capitalone/dashboard/service/CodeQualityServiceTest.java
@@ -1,0 +1,112 @@
+package com.capitalone.dashboard.service;
+
+import com.capitalone.dashboard.misc.HygieiaException;
+import com.capitalone.dashboard.model.CodeQuality;
+import com.capitalone.dashboard.model.CodeQualityMetric;
+import com.capitalone.dashboard.model.CodeQualityMetricStatus;
+import com.capitalone.dashboard.model.CodeQualityType;
+import com.capitalone.dashboard.model.Collector;
+import com.capitalone.dashboard.model.CollectorItem;
+import com.capitalone.dashboard.repository.CodeQualityRepository;
+import com.capitalone.dashboard.repository.CollectorRepository;
+import com.capitalone.dashboard.request.CodeQualityCreateRequest;
+import org.bson.types.ObjectId;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CodeQualityServiceTest {
+
+    @Mock private CodeQualityRepository codeQualityRepository;
+    @Mock private CollectorRepository collectorRepository;
+    @Mock private CollectorService collectorService;
+    @InjectMocks private CodeQualityServiceImpl codeQualityService;
+
+
+    @Test
+    public void createWithGoodRequest() throws HygieiaException {
+        ObjectId collectorId = ObjectId.get();
+
+        CodeQualityCreateRequest request = makeCodeQualityRequest();
+
+        when(collectorRepository.findOne(collectorId)).thenReturn(new Collector());
+        when(collectorService.createCollector(any(Collector.class))).thenReturn(new Collector());
+        when(collectorService.createCollectorItem(any(CollectorItem.class))).thenReturn(new CollectorItem());
+
+        CodeQuality codeQuality = makeCodeQualityStatic();
+
+        when(codeQualityRepository.save(any(CodeQuality.class))).thenReturn(codeQuality);
+        String response = codeQualityService.create(request);
+        String expected = codeQuality.getId().toString();
+        assertEquals(response, expected);
+    }
+
+    @Test
+    public void createV2WithGoodRequest() throws HygieiaException {
+        ObjectId collectorId = ObjectId.get();
+
+        CodeQualityCreateRequest request = makeCodeQualityRequest();
+
+        when(collectorRepository.findOne(collectorId)).thenReturn(new Collector());
+        when(collectorService.createCollector(any(Collector.class))).thenReturn(new Collector());
+        when(collectorService.createCollectorItem(any(CollectorItem.class))).thenReturn(new CollectorItem());
+
+        CodeQuality codeQuality = makeCodeQualityStatic();
+
+        when(codeQualityRepository.save(any(CodeQuality.class))).thenReturn(codeQuality);
+        String response = codeQualityService.createV2(request);
+        String expected = codeQuality.getId().toString() + "," + codeQuality.getCollectorItemId();
+        assertEquals(response, expected);
+    }
+
+
+    private CodeQualityCreateRequest makeCodeQualityRequest() {
+        CodeQualityCreateRequest quality = new CodeQualityCreateRequest();
+        quality.setHygieiaId(ObjectId.get().toString());
+        quality.setProjectId("1234");
+        quality.setTimestamp(1);
+        quality.setProjectName("MyTest");
+        quality.setType(CodeQualityType.StaticAnalysis);
+        quality.setProjectUrl("http://mycompany.sonar.com/MyTest");
+        quality.setServerUrl("http://mycompany.sonar.com");
+        quality.setProjectVersion("1.0.0.1");
+        quality.getMetrics().add(makeMetric());
+        return quality;
+    }
+
+    private CodeQuality makeCodeQualityStatic() {
+        CodeQuality quality = new CodeQuality();
+        quality.setId(ObjectId.get());
+        quality.setCollectorItemId(ObjectId.get());
+        quality.setTimestamp(1);
+        quality.setName("MyTest");
+        quality.setType(CodeQualityType.StaticAnalysis);
+        quality.setUrl("http://mycompany.sonar.com/MyTest");
+        quality.setVersion("1.0.0.1");
+        quality.getMetrics().add(makeMetric());
+        return quality;
+    }
+
+
+    private CodeQualityMetric makeMetric() {
+        CodeQualityMetric metric = new CodeQualityMetric("critical");
+        metric.setFormattedValue("10");
+        metric.setStatus(CodeQualityMetricStatus.Ok);
+        metric.setStatusMessage("Ok");
+        metric.setValue("0");
+        return metric;
+    }
+
+    private int intVal(long value) {
+        return Long.valueOf(value).intValue();
+    }
+
+
+}

--- a/api/src/test/java/com/capitalone/dashboard/service/DeployServiceTest.java
+++ b/api/src/test/java/com/capitalone/dashboard/service/DeployServiceTest.java
@@ -4,6 +4,7 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyLong;
 import static org.mockito.Mockito.times;
@@ -66,7 +67,7 @@ public class DeployServiceTest {
         CollectorItem item = new CollectorItem();
         item.setId(ObjectId.get());
         item.setCollectorId(ObjectId.get());
-        component.getCollectorItems().put(CollectorType.Deployment, Arrays.asList(item));
+        component.getCollectorItems().put(CollectorType.Deployment, Collections.singletonList(item));
         when(componentRepository.findOne(compId)).thenReturn(component);
         when(collectorRepository.findOne(item.getCollectorId())).thenReturn(new Collector());
 
@@ -276,7 +277,7 @@ public class DeployServiceTest {
     }
     
     @Test
-    public void collectorIsCreatedFromCollectorNamePropertyIfPresent() throws HygieiaException {
+    public void collectorIsCreatedFromCollectorNamePropertyIfPresent_v2() throws HygieiaException {
         DeployDataCreateRequest request = makeDataCreateRequest();
         Collector expectedCollector = makeCollector();
         when(collectorService.createCollector(any())).thenReturn(expectedCollector);
@@ -292,11 +293,35 @@ public class DeployServiceTest {
         co.setCollectorItemId(id2);
         when(environmentComponentRepository.save((EnvironmentComponent)any()))
             .thenReturn(co);
-        String output = deployService.create(request);
+        String output = deployService.createV2(request);
         ArgumentCaptor<Collector> collectorCaptor = ArgumentCaptor.forClass(Collector.class);
         verify(collectorService, times(1)).createCollector(collectorCaptor.capture());
         assertEquals("customCollector", collectorCaptor.getValue().getName());
         assertEquals(id.toString()+","+ id2.toString(), output);
+    }
+
+    @Test
+    public void collectorIsCreatedFromCollectorNamePropertyIfPresent() throws HygieiaException {
+        DeployDataCreateRequest request = makeDataCreateRequest();
+        Collector expectedCollector = makeCollector();
+        when(collectorService.createCollector(any())).thenReturn(expectedCollector);
+        CollectorItem expectedItem = makeCollectorItem();
+        when(collectorService.createCollectorItem(any())).thenReturn(expectedItem);
+        when(environmentComponentRepository.findByUniqueKey(any(), any(), any(), anyLong()))
+                .thenReturn(null);
+        EnvironmentComponent co = new EnvironmentComponent();
+        ObjectId id = new ObjectId();
+        co.setId(id);
+        ObjectId id2 = new ObjectId();
+        setUpCollector(id, id2);
+        co.setCollectorItemId(id2);
+        when(environmentComponentRepository.save((EnvironmentComponent)any()))
+                .thenReturn(co);
+        String output = deployService.create(request);
+        ArgumentCaptor<Collector> collectorCaptor = ArgumentCaptor.forClass(Collector.class);
+        verify(collectorService, times(1)).createCollector(collectorCaptor.capture());
+        assertEquals("customCollector", collectorCaptor.getValue().getName());
+        assertEquals(id.toString(), output);
     }
 
     @Test
@@ -311,7 +336,7 @@ public class DeployServiceTest {
         when(collectorItemRepository.findByOptionsAndDeployedApplicationName(id1, "appName"))
             .thenReturn(Collections.emptyList());
         when(collectorItemRepository.findByOptionsAndDeployedApplicationName(id2, "appName"))
-            .thenReturn(Arrays.asList(makeCollectorItem()));
+            .thenReturn(Collections.singletonList(makeCollectorItem()));
         when(environmentComponentRepository.findByCollectorItemId(any()))
             .thenReturn(Collections.emptyList());
         Collector collector = makeCollector();
@@ -336,12 +361,72 @@ public class DeployServiceTest {
         setUpCollector(id, id2);
         ArgumentCaptor<EnvironmentComponent> captor = ArgumentCaptor.forClass(EnvironmentComponent.class);
         String output = deployService.createRundeckBuild(doc, new HashMap<>(), executionId, status);
+        assertEquals(id.toString(), output);
+        verify(environmentComponentRepository, times(1)).save(captor.capture());
+        EnvironmentComponent value = captor.getValue();
+        assertTrue(value.isDeployed());
+        assertEquals("http://localhost:4440/project/Test/execution/follow/22", value.getJobUrl());
+        assertEquals(1481001727759L, value.getDeployTime());
+    }
+
+    @Test
+    public void rundeckDocumentCreatesValidDeployRequest_v2() throws Exception {
+        InputStream body = DeployServiceTest.class.getResourceAsStream("rundeck_request.xml");
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        DocumentBuilder builder = factory.newDocumentBuilder();
+        Document doc = builder.parse(new InputSource(body));
+        String executionId = "22";
+        String status = "success";
+        ObjectId id = new ObjectId();
+        ObjectId id2 = new ObjectId();
+        setUpCollector(id, id2);
+        ArgumentCaptor<EnvironmentComponent> captor = ArgumentCaptor.forClass(EnvironmentComponent.class);
+        String output = deployService.createRundeckBuildV2(doc, new HashMap<>(), executionId, status);
         assertEquals(id.toString() + "," + id2.toString(), output);
         verify(environmentComponentRepository, times(1)).save(captor.capture());
         EnvironmentComponent value = captor.getValue();
-        assertEquals(true, value.isDeployed());
+        assertTrue(value.isDeployed());
         assertEquals("http://localhost:4440/project/Test/execution/follow/22", value.getJobUrl());
         assertEquals(1481001727759L, value.getDeployTime());
+    }
+
+
+    @Test
+    public void createDeployRequest_v2() throws Exception {
+        ObjectId collectorId = ObjectId.get();
+
+        DeployDataCreateRequest request = makeDataCreateRequest();
+
+        when(collectorRepository.findOne(collectorId)).thenReturn(new Collector());
+        when(collectorService.createCollector(any(Collector.class))).thenReturn(new Collector());
+        when(collectorService.createCollectorItem(any(CollectorItem.class))).thenReturn(new CollectorItem());
+
+        EnvironmentComponent environmentComponent = makeEnvComponent("QA", "API", "1.1", true);
+
+        when(environmentComponentRepository.save(any(EnvironmentComponent.class))).thenReturn(environmentComponent);
+        String response = deployService.createV2(request);
+        String expected = environmentComponent.getId().toString() + "," + environmentComponent.getCollectorItemId();
+        assertEquals(response, expected);
+    }
+
+
+
+    @Test
+    public void createDeployRequest() throws Exception {
+        ObjectId collectorId = ObjectId.get();
+
+        DeployDataCreateRequest request = makeDataCreateRequest();
+
+        when(collectorRepository.findOne(collectorId)).thenReturn(new Collector());
+        when(collectorService.createCollector(any(Collector.class))).thenReturn(new Collector());
+        when(collectorService.createCollectorItem(any(CollectorItem.class))).thenReturn(new CollectorItem());
+
+        EnvironmentComponent environmentComponent = makeEnvComponent("QA", "API", "1.1", true);
+
+        when(environmentComponentRepository.save(any(EnvironmentComponent.class))).thenReturn(environmentComponent);
+        String response = deployService.create(request);
+        String expected = environmentComponent.getId().toString();
+        assertEquals(response, expected);
     }
 
     private void setUpCollector(ObjectId id1, ObjectId id2) {
@@ -362,6 +447,8 @@ public class DeployServiceTest {
         comp.setComponentName(name);
         comp.setComponentVersion(version);
         comp.setDeployed(deployed);
+        comp.setCollectorItemId(ObjectId.get());
+        comp.setId(ObjectId.get());
         return comp;
     }
 

--- a/api/src/test/java/com/capitalone/dashboard/service/TestResultServiceTest.java
+++ b/api/src/test/java/com/capitalone/dashboard/service/TestResultServiceTest.java
@@ -1,0 +1,172 @@
+package com.capitalone.dashboard.service;
+
+import com.capitalone.dashboard.misc.HygieiaException;
+import com.capitalone.dashboard.model.Collector;
+import com.capitalone.dashboard.model.CollectorItem;
+import com.capitalone.dashboard.model.TestCapability;
+import com.capitalone.dashboard.model.TestCase;
+import com.capitalone.dashboard.model.TestCaseStatus;
+import com.capitalone.dashboard.model.TestResult;
+import com.capitalone.dashboard.model.TestSuite;
+import com.capitalone.dashboard.model.TestSuiteType;
+import com.capitalone.dashboard.repository.CollectorRepository;
+import com.capitalone.dashboard.repository.TestResultRepository;
+import com.capitalone.dashboard.request.TestDataCreateRequest;
+import org.bson.types.ObjectId;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class TestResultServiceTest {
+
+    @Mock private TestResultRepository testResultRepository;
+    @Mock private CollectorRepository collectorRepository;
+    @Mock private CollectorService collectorService;
+    @InjectMocks private TestResultServiceImpl testResultService;
+
+
+    @Test
+    public void createWithGoodRequest() throws HygieiaException {
+        ObjectId collectorId = ObjectId.get();
+
+        TestDataCreateRequest request = makeTestDateCreateRequest();
+
+        when(collectorRepository.findOne(collectorId)).thenReturn(new Collector());
+        when(collectorService.createCollector(any(Collector.class))).thenReturn(new Collector());
+        when(collectorService.createCollectorItem(any(CollectorItem.class))).thenReturn(new CollectorItem());
+
+        TestResult testResult = makeTestResult();
+
+        when(testResultRepository.save(any(TestResult.class))).thenReturn(testResult);
+        String response = testResultService.create(request);
+        String expected = testResult.getId().toString();
+        assertEquals(response, expected);
+    }
+
+    @Test
+    public void createV2WithGoodRequest() throws HygieiaException {
+        ObjectId collectorId = ObjectId.get();
+
+        TestDataCreateRequest request = makeTestDateCreateRequest();
+
+        when(collectorRepository.findOne(collectorId)).thenReturn(new Collector());
+        when(collectorService.createCollector(any(Collector.class))).thenReturn(new Collector());
+        when(collectorService.createCollectorItem(any(CollectorItem.class))).thenReturn(new CollectorItem());
+
+        TestResult testResult = makeTestResult();
+
+        when(testResultRepository.save(any(TestResult.class))).thenReturn(testResult);
+        String response = testResultService.createV2(request);
+        String expected = testResult.getId().toString() + "," + testResult.getCollectorItemId();
+        assertEquals(response, expected);
+    }
+
+    private TestDataCreateRequest makeTestDateCreateRequest() {
+        TestDataCreateRequest data = new TestDataCreateRequest();
+        data.setExecutionId(ObjectId.get().toString());
+        data.setTestJobId(ObjectId.get().toString());
+        data.setDescription("description");
+        data.setDuration(1L);
+        data.setExecutionId("execution ID");
+        data.setStartTime(2L);
+        data.setEndTime(3L);
+        data.setFailureCount(1);
+        data.setSuccessCount(2);
+        data.setSkippedCount(0);
+        data.setTotalCount(3);
+
+        TestCapability capability = new TestCapability();
+        capability.setDescription("description");
+        capability.setDuration(1L);
+        capability.setStartTime(2L);
+        capability.setEndTime(3L);
+        capability.setFailedTestSuiteCount(1);
+        capability.setSkippedTestSuiteCount(2);
+        capability.setSuccessTestSuiteCount(3);
+        capability.setTotalTestSuiteCount(6);
+
+        TestSuite suite = new TestSuite();
+        suite.setDescription("description");
+        suite.setDuration(1L);
+        suite.setStartTime(2L);
+        suite.setEndTime(3L);
+        suite.setType(TestSuiteType.Functional);
+        suite.setFailedTestCaseCount(1);
+        suite.setSuccessTestCaseCount(2);
+        suite.setSkippedTestCaseCount(0);
+        suite.setTotalTestCaseCount(3);
+
+        capability.getTestSuites().add(suite);
+        data.getTestCapabilities().add(capability);
+
+        TestCase testCase = new TestCase();
+        testCase.setId("id");
+        testCase.setDescription("description");
+        testCase.setStatus(TestCaseStatus.Failure);
+        testCase.setDuration(20l);
+
+        suite.getTestCases().add(testCase);
+
+        return data;
+    }
+
+
+    private TestResult makeTestResult() {
+        TestResult result = new TestResult();
+        result.setId(ObjectId.get());
+        result.setCollectorItemId(ObjectId.get());
+        result.setDescription("description");
+        result.setDuration(1L);
+        result.setExecutionId("execution ID");
+        result.setStartTime(2L);
+        result.setEndTime(3L);
+        result.setUrl("http://foo.com");
+        result.setFailureCount(1);
+        result.setSuccessCount(2);
+        result.setSkippedCount(0);
+        result.setTotalCount(3);
+
+        TestCapability capability = new TestCapability();
+        capability.setDescription("description");
+        capability.setDuration(1l);
+        capability.setStartTime(2l);
+        capability.setEndTime(3l);
+        capability.setFailedTestSuiteCount(1);
+        capability.setSkippedTestSuiteCount(2);
+        capability.setSuccessTestSuiteCount(3);
+        capability.setTotalTestSuiteCount(6);
+
+        TestSuite suite = new TestSuite();
+        suite.setDescription("description");
+        suite.setDuration(1L);
+        suite.setStartTime(2L);
+        suite.setEndTime(3L);
+        suite.setType(TestSuiteType.Functional);
+        suite.setFailedTestCaseCount(1);
+        suite.setSuccessTestCaseCount(2);
+        suite.setSkippedTestCaseCount(0);
+        suite.setTotalTestCaseCount(3);
+
+        capability.getTestSuites().add(suite);
+        result.getTestCapabilities().add(capability);
+
+        TestCase testCase = new TestCase();
+        testCase.setId("id");
+        testCase.setDescription("description");
+        testCase.setStatus(TestCaseStatus.Failure);
+        testCase.setDuration(20L);
+
+        suite.getTestCases().add(testCase);
+
+        return result;
+    }
+
+
+}

--- a/hygieia-jenkins-plugin/src/main/java/jenkins/plugins/hygieia/DefaultHygieiaService.java
+++ b/hygieia-jenkins-plugin/src/main/java/jenkins/plugins/hygieia/DefaultHygieiaService.java
@@ -55,7 +55,7 @@ public class DefaultHygieiaService implements HygieiaService {
         try {
             String jsonString = new String(HygieiaUtils.convertObjectToJsonBytes(request));
             RestCall restCall = new RestCall(useProxy);
-            RestCall.RestCallResponse callResponse = restCall.makeRestCallPost(hygieiaAPIUrl + "/build", jsonString);
+            RestCall.RestCallResponse callResponse = restCall.makeRestCallPost(hygieiaAPIUrl + "/v2/build", jsonString);
             responseCode = callResponse.getResponseCode();
             responseValue = callResponse.getResponseString().replaceAll("\"", "");
             if (responseCode != HttpStatus.SC_CREATED) {
@@ -98,7 +98,7 @@ public class DefaultHygieiaService implements HygieiaService {
         try {
             String jsonString = new String(HygieiaUtils.convertObjectToJsonBytes(request));
             RestCall restCall = new RestCall(useProxy);
-            RestCall.RestCallResponse callResponse = restCall.makeRestCallPost(hygieiaAPIUrl + "/quality/test", jsonString);
+            RestCall.RestCallResponse callResponse = restCall.makeRestCallPost(hygieiaAPIUrl + "/v2/quality/test", jsonString);
             responseCode = callResponse.getResponseCode();
             responseValue = callResponse.getResponseString();
             if (responseCode != HttpStatus.SC_CREATED) {
@@ -119,7 +119,7 @@ public class DefaultHygieiaService implements HygieiaService {
         try {
             String jsonString = new String(HygieiaUtils.convertObjectToJsonBytes(request));
             RestCall restCall = new RestCall(useProxy);
-            RestCall.RestCallResponse callResponse = restCall.makeRestCallPost(hygieiaAPIUrl + "/quality/static-analysis", jsonString);
+            RestCall.RestCallResponse callResponse = restCall.makeRestCallPost(hygieiaAPIUrl + "/v2/quality/static-analysis", jsonString);
             responseCode = callResponse.getResponseCode();
             responseValue = callResponse.getResponseString();
             if (responseCode != HttpStatus.SC_CREATED) {
@@ -138,7 +138,7 @@ public class DefaultHygieiaService implements HygieiaService {
         try {
             String jsonString = new String(HygieiaUtils.convertObjectToJsonBytes(request));
             RestCall restCall = new RestCall(useProxy);
-            RestCall.RestCallResponse callResponse = restCall.makeRestCallPost(hygieiaAPIUrl + "/deploy", jsonString);
+            RestCall.RestCallResponse callResponse = restCall.makeRestCallPost(hygieiaAPIUrl + "/v2/deploy", jsonString);
             responseCode = callResponse.getResponseCode();
             responseValue = callResponse.getResponseString();
             if (responseCode != HttpStatus.SC_CREATED) {

--- a/hygieia-jenkins-plugin/src/main/java/jenkins/plugins/hygieia/HygieiaGlobalListener.java
+++ b/hygieia-jenkins-plugin/src/main/java/jenkins/plugins/hygieia/HygieiaGlobalListener.java
@@ -49,6 +49,8 @@ public class HygieiaGlobalListener extends RunListener<Run<?, ?>> {
                     listener.getLogger().println("Hygieia: Auto Published Build Complete Data. " + buildResponse.toString());
                 } else {
                     listener.getLogger().println("Hygieia: Failed Publishing Build Complete Data. " + buildResponse.toString());
+                    //If publish build data fails, skip rest of publishing steps.
+                    return;
                 }
             }
 


### PR DESCRIPTION
## Changes
- Build, Code Quality, Test and Deploy POST end points now return document id and collector item id. This potentially breaks older clients. Added /v2/ rest endpoints for these keeping the old one as is. 

- Minor update to Jenkins plugin: If build publish fails, do not try to publish anything else as the build objectID is necessary to relate other information.