### PR TITLE
Remote dashboard create and update enhancement 

### DIFF
--- a/api/src/main/java/com/capitalone/dashboard/service/DashboardRemoteServiceImpl.java
+++ b/api/src/main/java/com/capitalone/dashboard/service/DashboardRemoteServiceImpl.java
@@ -60,7 +60,7 @@ public class DashboardRemoteServiceImpl implements DashboardRemoteService {
             throw new HygieiaException("Invalid owner information or authentication type. Owner first needs to sign up in Hygieia", HygieiaException.BAD_DATA);
         }
 
-        List<Dashboard> dashboards = dashboardRepository.findByTitle(request.getMetaData().getTitle());
+        List<Dashboard> dashboards = findExistingDashboardsFromRequest( request );
         if (!CollectionUtils.isEmpty(dashboards)) {
             dashboard = dashboards.get(0);
             if (!isUpdate) {
@@ -73,7 +73,7 @@ public class DashboardRemoteServiceImpl implements DashboardRemoteService {
 
         } else {
             if (isUpdate) {
-                throw new HygieiaException("Dashboard " + request.getMetaData().getTitle() +  "does not exist.", HygieiaException.BAD_DATA);
+                throw new HygieiaException("Dashboard " + request.getMetaData().getTitle() +  " does not exist.", HygieiaException.BAD_DATA);
             }
             dashboard = dashboardService.create(requestToDashboard(request));
         }
@@ -118,6 +118,23 @@ public class DashboardRemoteServiceImpl implements DashboardRemoteService {
             }
         }
         return (dashboard != null) ? dashboardService.get(dashboard.getId()) : null;
+    }
+
+    /**
+     * Takes a DashboardRemoteRequest. If the request contains a Business Service and Business Application then returns dashboard. Otherwise,
+     * Checks dashboards for existing Title and returns dashboards.
+     * @param request
+     * @return  List< Dashboard >
+     */
+    private List< Dashboard > findExistingDashboardsFromRequest( DashboardRemoteRequest request ) {
+        String businessService = request.getMetaData().getBusinessService();
+        String businessApplication = request.getMetaData().getBusinessApplication();
+
+        if( !StringUtils.isEmpty( businessService ) && !StringUtils.isEmpty( businessApplication ) ){
+           return dashboardRepository.findAllByConfigurationItemBusServNameContainingIgnoreCaseAndConfigurationItemBusAppNameContainingIgnoreCase( businessService, businessApplication );
+        }else {
+           return dashboardRepository.findByTitle( request.getMetaData().getTitle() );
+        }
     }
 
 

--- a/api/src/test/java/com/capitalone/dashboard/fixture/DashboardFixture.java
+++ b/api/src/test/java/com/capitalone/dashboard/fixture/DashboardFixture.java
@@ -38,6 +38,8 @@ package com.capitalone.dashboard.fixture;
 		 metaData.setTemplate(template);
 		 metaData.setTitle(title);
 		 metaData.setType(type);
+		 metaData.setBusinessApplication(configItemComponentName);
+		 metaData.setBusinessService(configItemAppName);
 		 request.setMetaData(metaData);
 
 


### PR DESCRIPTION
Changes to all dashboards to be updated based on the provided Business Service and Business Application and not just the title. 

With old logic if a Dashboard exist with a Business Service and Business Application but was being updated via the API and the Titles didn't match, the update would fail. Dashboards with a Business Service and Business Application combination are unique so the dashboard should be updated, if they match, no matter what the title is.