### PR TITLE
Fix for the unlimited amount of console errors For Open Source Widget

### DIFF
--- a/UI/src/components/widgets/codeanalysis/view.js
+++ b/UI/src/components/widgets/codeanalysis/view.js
@@ -293,7 +293,7 @@
             }
 
             ctrl.getDashStatus = function getDashStatus() {
-
+                if(ctrl.librarySecurityThreatStatus == undefined) return 'ignore';
                 switch (ctrl.librarySecurityThreatStatus.level) {
                     case 4:
                         return 'critical';


### PR DESCRIPTION
When there is no data the console will not stop through errors added this if check to fix the undefined value.