### PR TITLE
Remove .m2 from cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ branches:
 
 cache:
   directories:
-    - "$HOME/.m2"
     - "$TRAVIS_BUILD_DIR/UI/node_modules"
 
 install: true


### PR DESCRIPTION
.m2 cache caches failed attempts to reach maven central which stops subsequent builds from pulling files even if they now exist. This does not allow us to rerun builds in a timely manner if we know the artifact is now there. 