### PR TITLE
Delete all test bug

### DIFF
--- a/api/api.properties
+++ b/api/api.properties
@@ -1,0 +1,8 @@
+dbname=dashboarddb
+#dbusername=dashboarduser
+#dbpassword=dbpassword
+dbhost=127.0.0.1
+dbport=27017
+server.contextPath=/api
+server.port=8080
+auth.authenticationProviders=STANDARD

--- a/api/api.properties
+++ b/api/api.properties
@@ -1,8 +1,0 @@
-dbname=dashboarddb
-#dbusername=dashboarduser
-#dbpassword=dbpassword
-dbhost=127.0.0.1
-dbport=27017
-server.contextPath=/api
-server.port=8080
-auth.authenticationProviders=STANDARD

--- a/api/src/main/java/com/capitalone/dashboard/service/DashboardServiceImpl.java
+++ b/api/src/main/java/com/capitalone/dashboard/service/DashboardServiceImpl.java
@@ -270,25 +270,30 @@ public class DashboardServiceImpl implements DashboardService {
                         ci.setEnabled(!isLonely(ci, collector, component));
                         toSaveCollectorItems.put(ci.getId(), ci);
                     }
-                }≠
+                }
                 // remove all collector items of a type
                 component.getCollectorItems().remove(collector.getCollectorType());
 
 
             }
         }
-//      if(incomingTypes.name.contains("Test") || incomingTypes.contains("CodeQuality") || incomingTypes.contains("LibraryPolicy") || incomingTypes.contains("StaticSecurityScan")){
-        System.out.println(incomingTypes.getClass());
-        // If a collector type is within the code analysis widget, check to see if any of the remaining fields were passed values
-        if(incomingTypes.contains(CollectorType.Test) == true){
-            System.out.println("Inside if");
-            if(incomingTypes.contains("Test")){
-                component.getCollectorItems().remove("Test");
-            }
-        } else {
-            System.out.println("Not true");
-        }
 
+        // If a collector type is within the code analysis widget, check to see if any of the remaining fields were passed values
+        if(incomingTypes.contains(CollectorType.Test) || incomingTypes.contains(CollectorType.StaticSecurityScan) || incomingTypes.contains(CollectorType.CodeQuality) || incomingTypes.contains(CollectorType.LibraryPolicy) ){
+            System.out.println("Inside if");
+            if(!incomingTypes.contains(CollectorType.Test)){
+                component.getCollectorItems().remove(CollectorType.Test);
+            }
+            if(!incomingTypes.contains(CollectorType.StaticSecurityScan)){
+                component.getCollectorItems().remove(CollectorType.StaticSecurityScan);
+            }
+            if(!incomingTypes.contains(CollectorType.CodeQuality)){
+                component.getCollectorItems().remove(CollectorType.CodeQuality);
+            }
+            if(!incomingTypes.contains(CollectorType.LibraryPolicy)){
+                component.getCollectorItems().remove(CollectorType.LibraryPolicy);
+            }
+        }
 
         //Last step: add collector items that came in
         for (ObjectId collectorItemId : collectorItemIds) {

--- a/api/src/main/java/com/capitalone/dashboard/service/DashboardServiceImpl.java
+++ b/api/src/main/java/com/capitalone/dashboard/service/DashboardServiceImpl.java
@@ -46,6 +46,8 @@ import com.google.common.collect.Lists;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import com.capitalone.dashboard.model.CollectorType.*;
+
 @Service
 public class DashboardServiceImpl implements DashboardService {
 
@@ -268,11 +270,25 @@ public class DashboardServiceImpl implements DashboardService {
                         ci.setEnabled(!isLonely(ci, collector, component));
                         toSaveCollectorItems.put(ci.getId(), ci);
                     }
-                }
+                }≠
                 // remove all collector items of a type
                 component.getCollectorItems().remove(collector.getCollectorType());
+
+
             }
         }
+//      if(incomingTypes.name.contains("Test") || incomingTypes.contains("CodeQuality") || incomingTypes.contains("LibraryPolicy") || incomingTypes.contains("StaticSecurityScan")){
+        System.out.println(incomingTypes.getClass());
+        // If a collector type is within the code analysis widget, check to see if any of the remaining fields were passed values
+        if(incomingTypes.contains(CollectorType.Test) == true){
+            System.out.println("Inside if");
+            if(incomingTypes.contains("Test")){
+                component.getCollectorItems().remove("Test");
+            }
+        } else {
+            System.out.println("Not true");
+        }
+
 
         //Last step: add collector items that came in
         for (ObjectId collectorItemId : collectorItemIds) {

--- a/api/src/main/java/com/capitalone/dashboard/service/DashboardServiceImpl.java
+++ b/api/src/main/java/com/capitalone/dashboard/service/DashboardServiceImpl.java
@@ -280,7 +280,6 @@ public class DashboardServiceImpl implements DashboardService {
 
         // If a collector type is within the code analysis widget, check to see if any of the remaining fields were passed values
         if(incomingTypes.contains(CollectorType.Test) || incomingTypes.contains(CollectorType.StaticSecurityScan) || incomingTypes.contains(CollectorType.CodeQuality) || incomingTypes.contains(CollectorType.LibraryPolicy) ){
-            System.out.println("Inside if");
             if(!incomingTypes.contains(CollectorType.Test)){
                 component.getCollectorItems().remove(CollectorType.Test);
             }


### PR DESCRIPTION
PR for issue TEART-21795

When a field is changed to empty in the quality widget it was not able to be saved, as the associateCollectorToComponent function only updates based off of new values being passed, not values omitted. This fix checks to see if other values from the quality widget are being updated so that if a value is missing, it can be assumed that the previous value (if there was any) was deleted. 

**Caveat: this will not work if _all_ values from the widget are deleted from the configure page as there is no way to determine the widget type is there are no collector types in the request. We would need to keep track of this relationship in order to fix this functionality. As an alternative, the delete button will delete the entire widget and all values, resulting in the same effect.