### PR TITLE
Don't deploy on master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,7 @@ before_script:
   - sudo chown -R $USER:$GROUP $TRAVIS_BUILD_DIR
 
 script:
-  - if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then mvn clean install -q; fi
-  - if [ "$TRAVIS_PULL_REQUEST" = "false" ] && [ "$TRAVIS_BRANCH" = "master" ]; then cp ./travis-utilities/deploy-snapshot.sh . && ./deploy-snapshot.sh; fi
+  - if [ "$TRAVIS_PULL_REQUEST" != "false" ] || [ "$TRAVIS_BRANCH" = "master" ]; then mvn clean install -q; fi
   - if [ "$TRAVIS_PULL_REQUEST" = "false" ] && [[ "$TRAVIS_BRANCH" =~ ^v[0-9]+\.[0-9]+\.[0-9]+.*$ ]]; then cp ./travis-utilities/release.sh . && ./release.sh; fi
 
 notifications:


### PR DESCRIPTION
This changes the behavior for merges to master. Currently builds are failing because the build triggered by merges to master attempt to deploy snapshots, but if the version in the pom is not a SNAPSHOT then it'll try to deploy a release and will fail due to insufficient permissions to overwrite an existing version. Now, on merge to master no deploy will be attempted.