### PR TITLE
Gitlab collector - fixes an inaccuracy at retrieving information

### DIFF
--- a/collectors/scm/gitlab/src/main/java/com/capitalone/dashboard/gitlab/DefaultGitlabGitClient.java
+++ b/collectors/scm/gitlab/src/main/java/com/capitalone/dashboard/gitlab/DefaultGitlabGitClient.java
@@ -13,6 +13,9 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestOperations;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
 import com.capitalone.dashboard.collector.GitlabSettings;
 import com.capitalone.dashboard.gitlab.model.GitlabCommit;
 import com.capitalone.dashboard.model.Commit;
@@ -25,6 +28,9 @@ import com.capitalone.dashboard.util.Supplier;
 
 @Component
 public class DefaultGitlabGitClient implements  GitlabGitClient {
+
+	
+    private static final Log LOG = LogFactory.getLog(DefaultGitlabGitClient.class);
 
     //Gitlab max results per page. Reduces amount of network calls.
     private static final int RESULTS_PER_PAGE = 100;
@@ -57,6 +63,7 @@ public class DefaultGitlabGitClient implements  GitlabGitClient {
 		int nextPage = 1;
 		while (hasMorePages) {
 			ResponseEntity<GitlabCommit[]> response = makeRestCall(apiUrl, apiToken);
+			LOG.info("page " + nextPage + ": " + response.getStatusCode());
 			List<Commit> pageOfCommits = responseMapper.map(response.getBody(), repo.getRepoUrl(), repo.getBranch());
 			commits.addAll(pageOfCommits);
 			if (pageOfCommits.size() < RESULTS_PER_PAGE) {

--- a/collectors/scm/gitlab/src/main/java/com/capitalone/dashboard/gitlab/GitlabUrlUtility.java
+++ b/collectors/scm/gitlab/src/main/java/com/capitalone/dashboard/gitlab/GitlabUrlUtility.java
@@ -3,8 +3,7 @@ package com.capitalone.dashboard.gitlab;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
+import java.time.format.DateTimeFormatter;
 import java.util.Calendar;
 import java.util.Date;
 
@@ -74,6 +73,7 @@ public class GitlabUrlUtility {
 				.queryParam(PER_PAGE_QUERY_PARAM_KEY, resultsPerPage)
 				.build(true).toUri();
 
+		LOG.info("---> Gitlab URI: " + uri.toString());
 		return uri;
     }
 
@@ -86,7 +86,9 @@ public class GitlabUrlUtility {
     }
 
 	public URI updatePage(URI uri, int nextPage) {
-		return UriComponentsBuilder.fromUri(uri).replaceQueryParam("page", nextPage).build(true).toUri();
+		URI ret = UriComponentsBuilder.fromUri(uri).replaceQueryParam("page", nextPage).build(true).toUri();
+		LOG.info("Paging - Gitlab URI updated to: " + ret.toString());
+		return ret;
 	}
 
 	private String getRepoHost() {
@@ -125,9 +127,7 @@ public class GitlabUrlUtility {
 		} else {
 			dt = getDate(new Date(repo.getLastUpdated()), 0, -10);
 		}
-		DateFormat df = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
-		String thisMoment = df.format(dt);
-		return thisMoment;
+		return DateTimeFormatter.ISO_INSTANT.format(dt.toInstant());
 	}
 
 	private Date getDate(Date dateInstance, int offsetDays, int offsetMinutes) {


### PR DESCRIPTION
The collector queried Gitlab with its current time, and then just added a 'Z' behind it.  It was inaccurate since the local time to the collector has not to be necessarily GMT.  Fixed in order to query a precise date and time.