### PR TITLE
Fix for Sonar api limit to 10000 results. Added max pages to 20.

### DIFF
--- a/collectors/build/sonar/src/main/java/com/capitalone/dashboard/collector/DefaultSonar6Client.java
+++ b/collectors/build/sonar/src/main/java/com/capitalone/dashboard/collector/DefaultSonar6Client.java
@@ -114,7 +114,11 @@ public class DefaultSonar6Client implements SonarClient {
     }
 
     private JSONArray getProjects(String url, String key, int pages, JSONArray jsonArray) throws ParseException {
-       for (int start=1;start<=pages;start++){
+        int maxPages = 20;
+        if(pages <= maxPages) {
+            maxPages = pages;
+        }
+       for (int start=1;start<=maxPages;start++){
             getProjects(url, key, jsonArray, start);
         }
         return  jsonArray;


### PR DESCRIPTION
Fix for Sonar api limit to 10000 results. Added max pages to 20 of page size 500. 
This serves as a temporary work around to get max of 10000 records. 
TODO : Add more filters to pull all the projects from Sonar.  