### PR TITLE
Fixes widget wipe out issue when calling remote dashboard Update API

### DIFF
--- a/api/src/main/java/com/capitalone/dashboard/service/DashboardRemoteServiceImpl.java
+++ b/api/src/main/java/com/capitalone/dashboard/service/DashboardRemoteServiceImpl.java
@@ -19,7 +19,6 @@ import com.capitalone.dashboard.repository.DashboardRepository;
 import com.capitalone.dashboard.request.DashboardRemoteRequest;
 import com.capitalone.dashboard.request.WidgetRequest;
 import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.collections.MapUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.bson.types.ObjectId;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -95,10 +94,10 @@ public class DashboardRemoteServiceImpl implements DashboardRemoteService {
                 List< CollectorItem > list = new ArrayList<>();
                 Component component = componentRepository.findOne( dashboard.getApplication().getComponents().get(0).getId() );
 
-                list.addAll( retrieveCollectorItemsByType( request.getFunctionalTestEntries() , component, CollectorType.Test ) );
-                list.addAll( retrieveCollectorItemsByType( request.getSecurityScanEntries() , component, CollectorType.StaticSecurityScan ) );
-                list.addAll( retrieveCollectorItemsByType( request.getStaticCodeEntries() , component, CollectorType.CodeQuality ) );
-                list.addAll( retrieveCollectorItemsByType( request.getLibraryScanEntries() , component, CollectorType.LibraryPolicy ) );
+                list.addAll( component.getCollectorItems(CollectorType.Test ));
+                list.addAll( component.getCollectorItems(CollectorType.StaticSecurityScan ) );
+                list.addAll( component.getCollectorItems(CollectorType.CodeQuality ) );
+                list.addAll( component.getCollectorItems(CollectorType.LibraryPolicy ) );
 
                 List< ObjectId > collectorItemIdList = list.stream().map( CollectorItem::getId).collect(Collectors.toList() );
                 widgetRequest.getCollectorItemIds().addAll( collectorItemIdList );
@@ -120,24 +119,6 @@ public class DashboardRemoteServiceImpl implements DashboardRemoteService {
             }
         }
         return (dashboard != null) ? dashboardService.get(dashboard.getId()) : null;
-    }
-
-    /**
-     * Returns the collectorItems currently associated to a dashboard, for a given CollectorType, when that CollectorType is not being passed in the request
-     * @param entry request entry
-     * @param component Component used to search in
-     * @param type CollectorType used as the search key
-     * @return list of collectorItems that match the given type in a component
-     */
-    private  List< CollectorItem > retrieveCollectorItemsByType( List< ? > entry, Component component, CollectorType type ){
-        List< CollectorItem > list = new ArrayList<>();
-
-        Map< CollectorType, List< CollectorItem > > map = component.getCollectorItems();
-        if( CollectionUtils.isEmpty( entry ) && MapUtils.getObject( map, type ) != null){
-            list.addAll( component.getCollectorItems( type ) );
-        }
-
-        return list;
     }
 
     /**

--- a/api/src/main/java/com/capitalone/dashboard/service/DashboardRemoteServiceImpl.java
+++ b/api/src/main/java/com/capitalone/dashboard/service/DashboardRemoteServiceImpl.java
@@ -5,6 +5,7 @@ import com.capitalone.dashboard.model.Application;
 import com.capitalone.dashboard.model.Cmdb;
 import com.capitalone.dashboard.model.Collector;
 import com.capitalone.dashboard.model.CollectorItem;
+import com.capitalone.dashboard.model.CollectorType;
 import com.capitalone.dashboard.model.Component;
 import com.capitalone.dashboard.model.Dashboard;
 import com.capitalone.dashboard.model.DashboardType;
@@ -12,11 +13,13 @@ import com.capitalone.dashboard.model.Widget;
 import com.capitalone.dashboard.model.ScoreDisplayType;
 import com.capitalone.dashboard.repository.CmdbRepository;
 import com.capitalone.dashboard.repository.CollectorRepository;
+import com.capitalone.dashboard.repository.ComponentRepository;
 import com.capitalone.dashboard.repository.CustomRepositoryQuery;
 import com.capitalone.dashboard.repository.DashboardRepository;
 import com.capitalone.dashboard.request.DashboardRemoteRequest;
 import com.capitalone.dashboard.request.WidgetRequest;
 import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections.MapUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.bson.types.ObjectId;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -26,6 +29,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 @Service
 public class DashboardRemoteServiceImpl implements DashboardRemoteService {
@@ -36,12 +40,13 @@ public class DashboardRemoteServiceImpl implements DashboardRemoteService {
     private final CollectorService collectorService;
     private final UserInfoService userInfoService;
     private final CmdbRepository cmdbRepository;
-
+    private final ComponentRepository componentRepository;
 
     @Autowired
     public DashboardRemoteServiceImpl(
             CollectorRepository collectorRepository,
-            CustomRepositoryQuery customRepositoryQuery, DashboardRepository dashboardRepository, DashboardService dashboardService, CollectorService collectorService, UserInfoService userInfoService, CmdbRepository cmdbRepository) {
+            CustomRepositoryQuery customRepositoryQuery,
+            DashboardRepository dashboardRepository, DashboardService dashboardService, CollectorService collectorService, UserInfoService userInfoService, CmdbRepository cmdbRepository, ComponentRepository componentRepository) {
         this.collectorRepository = collectorRepository;
         this.customRepositoryQuery = customRepositoryQuery;
         this.dashboardRepository = dashboardRepository;
@@ -49,6 +54,7 @@ public class DashboardRemoteServiceImpl implements DashboardRemoteService {
         this.collectorService = collectorService;
         this.userInfoService = userInfoService;
         this.cmdbRepository = cmdbRepository;
+        this.componentRepository = componentRepository;
     }
 
     @Override
@@ -79,29 +85,25 @@ public class DashboardRemoteServiceImpl implements DashboardRemoteService {
         }
 
         List<DashboardRemoteRequest.Entry> entries = request.getAllEntries();
-        Map<String, WidgetRequest> allWidgetRequests = new HashMap<>();
-
-        for (DashboardRemoteRequest.Entry entry : entries) {
-            List<Collector> collectors = collectorRepository.findByCollectorTypeAndName(entry.getType(), entry.getToolName());
-            if (CollectionUtils.isEmpty(collectors)) {
-                throw new HygieiaException(entry.getToolName() + " collector is not available.", HygieiaException.BAD_DATA);
-            }
-            Collector collector = collectors.get(0);
-            WidgetRequest widgetRequest = allWidgetRequests.get(entry.getWidgetName());
-
-            if (widgetRequest == null) {
-                widgetRequest = entryToWidgetRequest(dashboard, entry, collector);
-                allWidgetRequests.put(entry.getWidgetName(), widgetRequest);
-            } else {
-                CollectorItem item = entryToCollectorItem(entry, collector);
-                if (item != null) {
-                    widgetRequest.getCollectorItemIds().add(item.getId());
-                }
-            }
-        }
-
+        Map<String, WidgetRequest> allWidgetRequests = generateRequestWidgetList( entries, dashboard);
+        //adds widgets
         for (String key : allWidgetRequests.keySet()) {
             WidgetRequest widgetRequest = allWidgetRequests.get(key);
+
+            if( key.equals( "codeanalysis" ) ){
+
+                List< CollectorItem > list = new ArrayList<>();
+                Component component = componentRepository.findOne( dashboard.getApplication().getComponents().get(0).getId() );
+
+                list.addAll( retrieveCollectorItemsByType( request.getFunctionalTestEntries() , component, CollectorType.Test ) );
+                list.addAll( retrieveCollectorItemsByType( request.getSecurityScanEntries() , component, CollectorType.StaticSecurityScan ) );
+                list.addAll( retrieveCollectorItemsByType( request.getStaticCodeEntries() , component, CollectorType.CodeQuality ) );
+                list.addAll( retrieveCollectorItemsByType( request.getLibraryScanEntries() , component, CollectorType.LibraryPolicy ) );
+
+                List< ObjectId > collectorItemIdList = list.stream().map( CollectorItem::getId).collect(Collectors.toList() );
+                widgetRequest.getCollectorItemIds().addAll( collectorItemIdList );
+            }
+
             Component component = dashboardService.associateCollectorToComponent(
                     dashboard.getApplication().getComponents().get(0).getId(), widgetRequest.getCollectorItemIds());
             Widget newWidget = widgetRequest.widget();
@@ -120,6 +122,55 @@ public class DashboardRemoteServiceImpl implements DashboardRemoteService {
         return (dashboard != null) ? dashboardService.get(dashboard.getId()) : null;
     }
 
+    /**
+     * Returns the collectorItems currently associated to a dashboard, for a given CollectorType, when that CollectorType is not being passed in the request
+     * @param entry request entry
+     * @param component Component used to search in
+     * @param type CollectorType used as the search key
+     * @return list of collectorItems that match the given type in a component
+     */
+    private  List< CollectorItem > retrieveCollectorItemsByType( List< ? > entry, Component component, CollectorType type ){
+        List< CollectorItem > list = new ArrayList<>();
+
+        Map< CollectorType, List< CollectorItem > > map = component.getCollectorItems();
+        if( CollectionUtils.isEmpty( entry ) && MapUtils.getObject( map, type ) != null){
+            list.addAll( component.getCollectorItems( type ) );
+        }
+
+        return list;
+    }
+
+    /**
+     * Generates a Widget Request list of Widgets to be created from the request
+     * @param entries
+     * @param dashboard
+     * @return Map< String, WidgetRequest > list of Widgets to be created
+     * @throws HygieiaException
+     */
+    private  Map < String, WidgetRequest > generateRequestWidgetList( List < DashboardRemoteRequest.Entry > entries, Dashboard dashboard ) throws HygieiaException {
+        Map< String, WidgetRequest > allWidgetRequests = new HashMap<>();
+        //builds widgets
+        for ( DashboardRemoteRequest.Entry entry : entries ) {
+
+            List < Collector > collectors = collectorRepository.findByCollectorTypeAndName( entry.getType(), entry.getToolName() );
+            if ( CollectionUtils.isEmpty( collectors ) ) {
+                throw new HygieiaException( entry.getToolName() + " collector is not available.", HygieiaException.BAD_DATA );
+            }
+            Collector collector = collectors.get( 0 );
+            WidgetRequest widgetRequest = allWidgetRequests.get( entry.getWidgetName() );
+
+            if ( widgetRequest == null ) {
+                widgetRequest = entryToWidgetRequest( dashboard, entry, collector) ;
+                allWidgetRequests.put( entry.getWidgetName(), widgetRequest );
+            } else {
+                CollectorItem item = entryToCollectorItem( entry, collector );
+                if ( item != null ) {
+                    widgetRequest.getCollectorItemIds().add( item.getId() );
+                }
+            }
+        }
+        return allWidgetRequests;
+    }
     /**
      * Takes a DashboardRemoteRequest. If the request contains a Business Service and Business Application then returns dashboard. Otherwise,
      * Checks dashboards for existing Title and returns dashboards.

--- a/api/src/test/java/com/capitalone/dashboard/config/ApiTestConfig.java
+++ b/api/src/test/java/com/capitalone/dashboard/config/ApiTestConfig.java
@@ -1,0 +1,43 @@
+package com.capitalone.dashboard.config;
+
+
+import com.capitalone.dashboard.auth.AuthProperties;
+import com.capitalone.dashboard.repository.CustomRepositoryQuery;
+import com.capitalone.dashboard.repository.CustomRepositoryQueryImpl;
+import com.capitalone.dashboard.settings.ApiSettings;
+import com.capitalone.dashboard.util.URLConnectionFactory;
+import org.mockito.Mockito;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.core.annotation.Order;
+
+
+/**
+ * Spring context configuration for Testing purposes
+ */
+@Order(1)
+@Configuration
+@ComponentScan(basePackages ={"com.capitalone.dashboard.service", "com.capitalone.dashboard.model"}, includeFilters = @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, value=ApiSettings.class))
+public class ApiTestConfig {
+
+    @Bean
+    public ApiSettings settings() {
+        ApiSettings settings = new ApiSettings();
+
+        return settings;
+    }
+
+    @Bean
+    public CustomRepositoryQuery customRepositoryQuery() { return Mockito.mock(CustomRepositoryQueryImpl.class); }
+    @Bean
+    public AuthProperties authProperties(){
+        return  Mockito.mock(AuthProperties.class);
+    }
+    @Bean
+    public URLConnectionFactory urlConnectionFactory(){
+        return Mockito.mock(URLConnectionFactory.class);
+    }
+
+}

--- a/api/src/test/java/com/capitalone/dashboard/config/FongoConfig.java
+++ b/api/src/test/java/com/capitalone/dashboard/config/FongoConfig.java
@@ -1,0 +1,19 @@
+package com.capitalone.dashboard.config;
+
+import com.github.fakemongo.Fongo;
+import com.mongodb.MongoClient;
+import org.springframework.context.annotation.Bean;
+
+public class FongoConfig extends MongoConfig {
+
+    @Override
+    @Bean
+    public MongoClient mongo()  {
+        return new Fongo(getDatabaseName()).getMongo();
+    }
+    
+    @Override
+    protected String getDatabaseName() {
+        return "test-db";
+    }
+}

--- a/api/src/test/java/com/capitalone/dashboard/service/DashboardRemoteServiceTest.java
+++ b/api/src/test/java/com/capitalone/dashboard/service/DashboardRemoteServiceTest.java
@@ -1,110 +1,95 @@
 package com.capitalone.dashboard.service;
 
+import com.capitalone.dashboard.config.FongoConfig;
+import com.capitalone.dashboard.config.ApiTestConfig;
 import com.capitalone.dashboard.misc.HygieiaException;
-import com.capitalone.dashboard.model.*;
-import com.capitalone.dashboard.repository.CmdbRepository;
+import com.capitalone.dashboard.model.Dashboard;
+import com.capitalone.dashboard.model.Component;
+import com.capitalone.dashboard.model.CollectorType;
+import com.capitalone.dashboard.model.Owner;
+import com.capitalone.dashboard.model.AuthType;
+import com.capitalone.dashboard.repository.CollectorItemRepository;
+import com.capitalone.dashboard.repository.DashboardRepository;
+import com.capitalone.dashboard.repository.UserInfoRepository;
 import com.capitalone.dashboard.repository.CollectorRepository;
 import com.capitalone.dashboard.repository.ComponentRepository;
-import com.capitalone.dashboard.repository.DashboardRepository;
 import com.capitalone.dashboard.request.DashboardRemoteRequest;
-import org.bson.types.ObjectId;
+import com.capitalone.dashboard.testutil.GsonUtil;
+import com.capitalone.dashboard.util.TestUtil;
+import com.github.fakemongo.junit.FongoRule;
+import com.google.common.io.Resources;
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+import org.apache.commons.io.IOUtils;
+import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.InjectMocks;
-import org.mockito.Matchers;
-import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
+import java.io.IOException;
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static com.capitalone.dashboard.fixture.DashboardFixture.makeDashboardRemoteRequest;
-import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.when;
+import static org.junit.Assert.assertNotNull;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(classes = {ApiTestConfig.class, FongoConfig.class})
+@DirtiesContext
 public class DashboardRemoteServiceTest {
 
-    @Mock
+    @Autowired
     private DashboardRepository dashboardRepository;
-    @Mock
-    private CmdbRepository cmdbRepository;
-    @Mock
+    @Autowired
+    private UserInfoRepository userInfoRepository;
+    @Autowired
     private CollectorRepository collectorRepository;
-    @Mock
+    @Autowired
     private ComponentRepository componentRepository;
-    @Mock
-    private UserInfoService userInfoService;
-    @Mock
+    @Autowired
+    private CollectorItemRepository collectorItemRepository;
+    @Autowired
     private DashboardService dashboardService;
-    @Mock
-    private CollectorService collectorService;
+    @Autowired
+    private DashboardRemoteService dashboardRemoteService;
 
-    @InjectMocks
-    private DashboardRemoteServiceImpl dashboardRemoteService;
-    @InjectMocks
-    private DashboardServiceImpl dashboardServiceImpl;
+    @Rule
+    public FongoRule fongoRule = new FongoRule();
 
-    private static final String configItemBusServName = "ASVTEST";
-    private static final String configItemBusAppName = "BAPTEST";
-
-    @Test
-    public void remoteCreate() throws HygieiaException {
-        Dashboard expected = makeTeamDashboard("template", "dashboardtitle", "appName", "someuser",configItemBusServName,configItemBusAppName, "comp1","comp2");
-        ObjectId objectId = ObjectId.get();
-        expected.setId(objectId);
-        DashboardRemoteRequest request = makeDashboardRemoteRequest("template", "dashboardtitle", "appName", "comp", "someuser", null, "team", configItemBusServName, configItemBusAppName);
-
-        when(userInfoService.isUserValid(request.getMetaData().getOwner().getUsername(), request.getMetaData().getOwner().getAuthType())).thenReturn(true);
-
-        when(dashboardRepository.findAllByConfigurationItemBusServNameContainingIgnoreCaseAndConfigurationItemBusAppNameContainingIgnoreCase( configItemBusServName, configItemBusAppName )).thenReturn(new ArrayList<Dashboard>());
-
-        Cmdb busApp = new Cmdb();
-        busApp.setConfigurationItem(configItemBusServName);
-        when(cmdbRepository.findByConfigurationItemAndItemType(configItemBusServName, "app")).thenReturn(busApp);
-
-        Cmdb busComp = new Cmdb();
-        busComp.setConfigurationItem(configItemBusAppName);
-        when(cmdbRepository.findByConfigurationItemAndItemType(configItemBusAppName, "component")).thenReturn(busComp);
-
-        when(dashboardService.create(Matchers.any(Dashboard.class))).thenReturn(expected);
-        when(dashboardService.get(objectId)).thenReturn(expected);
-
-        assertThat(dashboardRemoteService.remoteCreate(request, false), is(expected));
+    @Before
+    public void loadStuff() throws IOException {
+        TestUtil.loadDashBoard(dashboardRepository);
+        TestUtil.loadUserInfo(userInfoRepository);
+        TestUtil.loadCollector(collectorRepository);
+        TestUtil.loadComponent(componentRepository);
+        TestUtil.loadCollectorItems(collectorItemRepository);
     }
+
     @Test
-    public void remoteCreateWithoutAppAndComp() throws HygieiaException {
-        Dashboard expected = makeTeamDashboard("template", "dashboardtitle", "appName", "someuser","","", "comp1","comp2");
-        ObjectId objectId = ObjectId.get();
-        expected.setId(objectId);
-        DashboardRemoteRequest request = makeDashboardRemoteRequest("template", "dashboardtitle", "appName", "comp", "someuser", null, "team", "", "");
+    public void remoteUpdateCodeRepo() throws IOException, HygieiaException {
 
-        when(userInfoService.isUserValid(request.getMetaData().getOwner().getUsername(), request.getMetaData().getOwner().getAuthType())).thenReturn(true);
-        when(dashboardRepository.findByTitle(request.getMetaData().getTitle())).thenReturn(new ArrayList<Dashboard>());
-        when(dashboardService.create(Matchers.any(Dashboard.class))).thenReturn(expected);
-        when(dashboardService.get(objectId)).thenReturn(expected);
+        DashboardRemoteRequest request = getRemoteRequest("./dashboardRemoteRequests/0-Remote-Update-Repo.json");
 
-        assertThat(dashboardRemoteService.remoteCreate(request, false), is(expected));
+        dashboardRemoteService.remoteCreate(request, true);
+        List<Dashboard> dashboard = dashboardService.getByTitle("TestSSA");
+        Component component = componentRepository.findOne(dashboard.get(0).getApplication().getComponents().get(0).getId());
+        assertEquals(2, component.getCollectorItems().get(CollectorType.SCM).size());
     }
+
     @Test
-    public void remoteCreateInvalidUser() throws HygieiaException {
-        Dashboard expected = makeTeamDashboard("template", "dashboardtitle", "appName", "invaliduser",configItemBusServName,configItemBusAppName, "comp1","comp2");
-        ObjectId objectId = ObjectId.get();
-        expected.setId(objectId);
-        DashboardRemoteRequest request = makeDashboardRemoteRequest("template", "dashboardtitle", "appName", "comp", "invaliduser", null, "team", configItemBusServName, configItemBusAppName);
-
-        when(userInfoService.isUserValid(request.getMetaData().getOwner().getUsername(), request.getMetaData().getOwner().getAuthType())).thenReturn(false);
-        when(dashboardRepository.findByTitle(request.getMetaData().getTitle())).thenReturn(new ArrayList<Dashboard>());
-        when(dashboardService.create(Matchers.any(Dashboard.class))).thenReturn(expected);
-        when(dashboardService.get(objectId)).thenReturn(expected);
-
-        Throwable t = new Throwable();
+    public void remoteCreateInvalidUser() throws IOException {
+        DashboardRemoteRequest request = getRemoteRequest("./dashboardRemoteRequests/0-Remote-Update-Repo.json");
+        Owner owner = new Owner("test123",AuthType.STANDARD);
+        request.getMetaData().setOwner(owner);
+                Throwable t = new Throwable();
         RuntimeException excep = new RuntimeException("Invalid owner information or authentication type. Owner first needs to sign up in Hygieia", t);
 
         try {
@@ -115,11 +100,25 @@ public class DashboardRemoteServiceTest {
         }
     }
     @Test
-    public void remoteCreateInvalidApp() throws HygieiaException {
-        DashboardRemoteRequest request = makeDashboardRemoteRequest("template", "dashboardtitle", "appName", "comp", "invaliduser", null, "team", configItemBusServName, configItemBusAppName);
+    public void remoteCreateInvalidApp() throws IOException {
+        DashboardRemoteRequest request = getRemoteRequest("./dashboardRemoteRequests/0-Remote-Update-Repo.json");
+        request.getMetaData().setTitle("test1234");
+        request.getMetaData().setBusinessService("test");
+        Throwable t = new Throwable();
+        RuntimeException excep = new RuntimeException("Invalid Business Service Name.", t);
 
-        when(userInfoService.isUserValid(request.getMetaData().getOwner().getUsername(), request.getMetaData().getOwner().getAuthType())).thenReturn(true);
-
+        try {
+            dashboardRemoteService.remoteCreate(request, false);
+            fail("Should throw RuntimeException");
+        } catch(Exception e) {
+            assertEquals(excep.getMessage(), e.getMessage());
+        }
+    }
+    @Test
+    public void remoteCreateInvalidComp() throws IOException {
+        DashboardRemoteRequest request = getRemoteRequest("./dashboardRemoteRequests/0-Remote-Update-Repo.json");
+        request.getMetaData().setTitle("test1234");
+        request.getMetaData().setBusinessApplication("test");
         Throwable t = new Throwable();
         RuntimeException excep = new RuntimeException("Invalid Business Application Name.", t);
 
@@ -131,13 +130,11 @@ public class DashboardRemoteServiceTest {
         }
     }
     @Test
-    public void remoteCreateInvalidComp() throws HygieiaException {
-        DashboardRemoteRequest request = makeDashboardRemoteRequest("template", "dashboardtitle", "appName", "comp", "invaliduser", null, "team", configItemBusServName, configItemBusAppName);
-
-        when(userInfoService.isUserValid(request.getMetaData().getOwner().getUsername(), request.getMetaData().getOwner().getAuthType())).thenReturn(true);
-        Cmdb busApp = new Cmdb();
-        busApp.setConfigurationItem(configItemBusServName);
-        when(cmdbRepository.findByConfigurationItemAndItemType(configItemBusServName, "app")).thenReturn(busApp);
+    public void remoteCreateInvalidCompAndApp() throws IOException {
+        DashboardRemoteRequest request = getRemoteRequest("./dashboardRemoteRequests/0-Remote-Update-Repo.json");
+        request.getMetaData().setTitle("test1234");
+        request.getMetaData().setBusinessApplication("test");
+        request.getMetaData().setBusinessService("test1");
         Throwable t = new Throwable();
         RuntimeException excep = new RuntimeException("Invalid Business Application Name.", t);
 
@@ -149,24 +146,11 @@ public class DashboardRemoteServiceTest {
         }
     }
     @Test
-    public void remoteCreateDuplicateDashboard() throws HygieiaException {
-        Dashboard expected = makeTeamDashboard("template", "dashboardtitle", "appName", "validuser","","", "comp1","comp2");
-        ObjectId objectId = ObjectId.get();
-        expected.setId(objectId);
-        DashboardRemoteRequest request = makeDashboardRemoteRequest("template", "dashboardtitle", "appName", "comp", "validuser", null, "team", "", "");
-
-        when(userInfoService.isUserValid(request.getMetaData().getOwner().getUsername(), request.getMetaData().getOwner().getAuthType())).thenReturn(false);
-
-        List<Dashboard> existingDashboards = new ArrayList<Dashboard>();
-        existingDashboards.add(expected);
-
-        when(userInfoService.isUserValid(request.getMetaData().getOwner().getUsername(), request.getMetaData().getOwner().getAuthType())).thenReturn(true);
-        when(dashboardRepository.findByTitle(request.getMetaData().getTitle())).thenReturn(existingDashboards);
-        when(dashboardService.create(Matchers.any(Dashboard.class))).thenReturn(expected);
-        when(dashboardService.get(objectId)).thenReturn(expected);
-
+    public void remoteCreateDuplicateDashboard() throws IOException {
+        DashboardRemoteRequest request = getRemoteRequest("./dashboardRemoteRequests/0-Remote-Update-Repo.json");
+        Dashboard dashboard = dashboardRepository.findByTitle(request.getMetaData().getTitle()).get(0);
         Throwable t = new Throwable();
-        RuntimeException excep = new RuntimeException("Dashboard dashboardtitle (id =" + expected.getId() + ") already exists", t);
+        RuntimeException excep = new RuntimeException("Dashboard "+dashboard.getTitle()+" (id =" + dashboard.getId() + ") already exists", t);
 
         try {
             dashboardRemoteService.remoteCreate(request, false);
@@ -175,23 +159,31 @@ public class DashboardRemoteServiceTest {
             assertEquals(excep.getMessage(), e.getMessage());
         }
     }
+    @Test
+    public void remoteCreate() throws HygieiaException, IOException  {
+        DashboardRemoteRequest request = getRemoteRequest("./dashboardRemoteRequests/0-Remote-Update-Repo.json");
+        request.getMetaData().setTitle("newDashboard0");
+        assertNotNull(dashboardRemoteService.remoteCreate(request, false));
+    }
+    @Test
+    public void remoteCreateWithoutAppAndComp() throws HygieiaException, IOException  {
+        DashboardRemoteRequest request = getRemoteRequest("./dashboardRemoteRequests/0-Remote-Update-Repo.json");
+        request.getMetaData().setTitle("newDashboard1");
+        request.getMetaData().setBusinessApplication("");
+        request.getMetaData().setBusinessService("");
+        assertNotNull(dashboardRemoteService.remoteCreate(request, false));
+    }
 
     @Test
-    public void remoteCreateWithInvalidCollector() throws HygieiaException {
-        Dashboard expected = makeTeamDashboard("template", "dashboardtitle", "appName", "someuser","","", "comp1","comp2");
-        ObjectId objectId = ObjectId.get();
-        expected.setId(objectId);
-        DashboardRemoteRequest request = makeDashboardRemoteRequest("template", "dashboardtitle", "appName", "comp", "someuser", null, "team", "", "");
-        List<DashboardRemoteRequest.CodeRepoEntry> entries = new ArrayList<DashboardRemoteRequest.CodeRepoEntry>();
+    public void remoteCreateWithInvalidCollector() throws IOException {
+        DashboardRemoteRequest request = getRemoteRequest("./dashboardRemoteRequests/0-Remote-Update-Repo.json");
+        request.getMetaData().setTitle("newDashboard2");
+        List<DashboardRemoteRequest.CodeRepoEntry> entries = new ArrayList<>();
+
         DashboardRemoteRequest.CodeRepoEntry invalidSCM = new DashboardRemoteRequest.CodeRepoEntry();
         invalidSCM.setToolName("Clearcase");
         entries.add(invalidSCM);
         request.setCodeRepoEntries(entries);
-
-        when(userInfoService.isUserValid(request.getMetaData().getOwner().getUsername(), request.getMetaData().getOwner().getAuthType())).thenReturn(true);
-        when(dashboardRepository.findByTitle(request.getMetaData().getTitle())).thenReturn(new ArrayList<Dashboard>());
-        when(dashboardService.create(Matchers.any(Dashboard.class))).thenReturn(expected);
-        when(dashboardService.get(objectId)).thenReturn(expected);
 
         Throwable t = new Throwable();
         RuntimeException excep = new RuntimeException(invalidSCM.getToolName() + " collector is not available.", t);
@@ -205,12 +197,11 @@ public class DashboardRemoteServiceTest {
     }
 
     @Test
-    public void remoteCreateSCM() throws HygieiaException {
-        Dashboard expected = makeTeamDashboard("template", "dashboardtitle", "appName", "someuser","","", "comp1","comp2");
-        ObjectId objectId = ObjectId.get();
-        expected.setId(objectId);
-        DashboardRemoteRequest request = makeDashboardRemoteRequest("template", "dashboardtitle", "appName", "comp", "someuser", null, "team", "", "");
-        List<DashboardRemoteRequest.CodeRepoEntry> entries = new ArrayList<DashboardRemoteRequest.CodeRepoEntry>();
+    public void remoteCreateSCM() throws HygieiaException, IOException  {
+        DashboardRemoteRequest request = getRemoteRequest("./dashboardRemoteRequests/Remote-Request-Base.json");
+        request.getMetaData().setTitle("newDashboard3");
+
+        List<DashboardRemoteRequest.CodeRepoEntry> entries = new ArrayList<>();
         DashboardRemoteRequest.CodeRepoEntry validSCM = new DashboardRemoteRequest.CodeRepoEntry();
         validSCM.setToolName("GitHub");
         Map options = new HashMap();
@@ -220,47 +211,18 @@ public class DashboardRemoteServiceTest {
         entries.add(validSCM);
         request.setCodeRepoEntries(entries);
 
-        when(userInfoService.isUserValid(request.getMetaData().getOwner().getUsername(), request.getMetaData().getOwner().getAuthType())).thenReturn(true);
-        when(dashboardRepository.findByTitle(request.getMetaData().getTitle())).thenReturn(new ArrayList<Dashboard>());
-        when(dashboardService.create(Matchers.any(Dashboard.class))).thenReturn(expected);
-        when(dashboardService.get(objectId)).thenReturn(expected);
+        dashboardRemoteService.remoteCreate(request, false);
+        List<Dashboard> dashboard = dashboardService.getByTitle("newDashboard3");
+        Component component = componentRepository.findOne(dashboard.get(0).getApplication().getComponents().get(0).getId());
+        assertEquals(1, component.getCollectorItems().get(CollectorType.SCM).size());
 
-        List<Collector> collectors = new ArrayList<Collector>();
-        Collector githubCollector = makeCollector("GitHub", CollectorType.SCM);
-        Map uniqueFields = new HashMap();
-        uniqueFields.put("branch", "");
-        uniqueFields.put("url", "");
-        githubCollector.setUniqueFields(uniqueFields);
-
-        Map allFields = new HashMap();
-        allFields.put("branch", "");
-        allFields.put("url", "");
-        allFields.put("userID", "");
-        allFields.put("password", "");
-        allFields.put("lastUpdate", "");
-        githubCollector.setAllFields(allFields);
-
-        collectors.add(githubCollector);
-
-        when( collectorRepository.findByCollectorTypeAndName(validSCM.getType(), validSCM.getToolName()) ).thenReturn(collectors);
-
-        CollectorItem item = makeCollectorItem();
-
-        when(  collectorService.createCollectorItemSelectOptions(Matchers.any(CollectorItem.class), Matchers.any(Map.class), Matchers.any(Map.class) ) ).thenReturn(item);
-
-        Component component = new Component();
-        component.addCollectorItem(CollectorType.SCM, item);
-
-        assertThat(dashboardRemoteService.remoteCreate(request, false), is(expected));
     }
 
     @Test
-    public void remoteCreateBuild() throws HygieiaException {
-        Dashboard expected = makeTeamDashboard("template", "dashboardtitle", "appName", "someuser","","", "comp1","comp2");
-        ObjectId objectId = ObjectId.get();
-        expected.setId(objectId);
-        DashboardRemoteRequest request = makeDashboardRemoteRequest("template", "dashboardtitle", "appName", "comp", "someuser", null, "team", "", "");
-        List<DashboardRemoteRequest.BuildEntry> entries = new ArrayList<DashboardRemoteRequest.BuildEntry>();
+    public void remoteCreateBuild() throws HygieiaException, IOException {
+        DashboardRemoteRequest request = getRemoteRequest("./dashboardRemoteRequests/Remote-Request-Base.json");
+        request.getMetaData().setTitle("newDashboard4");
+        List<DashboardRemoteRequest.BuildEntry> entries = new ArrayList<>();
         DashboardRemoteRequest.BuildEntry validBuild = new DashboardRemoteRequest.BuildEntry();
         validBuild.setToolName("Hudson");
         Map options = new HashMap();
@@ -271,44 +233,30 @@ public class DashboardRemoteServiceTest {
         entries.add(validBuild);
         request.setBuildEntries(entries);
 
-        when(userInfoService.isUserValid(request.getMetaData().getOwner().getUsername(), request.getMetaData().getOwner().getAuthType())).thenReturn(true);
-        when(dashboardRepository.findByTitle(request.getMetaData().getTitle())).thenReturn(new ArrayList<Dashboard>());
-        when(dashboardService.create(Matchers.any(Dashboard.class))).thenReturn(expected);
-        when(dashboardService.get(objectId)).thenReturn(expected);
-
-        List<Collector> collectors = new ArrayList<Collector>();
-        Collector hudsonCollector = makeCollector("Hudson", CollectorType.Build);
-        Map uniqueFields = new HashMap();
-        uniqueFields.put("jobName", "");
-        uniqueFields.put("jobUrl", "");
-        uniqueFields.put("instanceUrl", "");
-        hudsonCollector.setUniqueFields(uniqueFields);
-
-        Map allFields = new HashMap();
-        allFields.put("jobName", "");
-        allFields.put("jobUrl", "");
-        allFields.put("instanceUrl", "");
-        hudsonCollector.setAllFields(allFields);
-
-        collectors.add(hudsonCollector);
-
-        when( collectorRepository.findByCollectorTypeAndName(validBuild.getType(), validBuild.getToolName()) ).thenReturn(collectors);
-
-        CollectorItem item = makeCollectorItem();
-
-        when(  collectorService.createCollectorItemSelectOptions(Matchers.any(CollectorItem.class), Matchers.any(Map.class), Matchers.any(Map.class) ) ).thenReturn(item);
-
-        Component component = new Component();
-        component.addCollectorItem(CollectorType.Build, item);
-
-        assertThat(dashboardRemoteService.remoteCreate(request, false), is(expected));
+        dashboardRemoteService.remoteCreate(request, false);
+        List<Dashboard> dashboard = dashboardService.getByTitle("newDashboard4");
+        Component component = componentRepository.findOne(dashboard.get(0).getApplication().getComponents().get(0).getId());
+        assertEquals(1, component.getCollectorItems().get(CollectorType.Build).size());
     }
     @Test
-    public void remoteCreateLibraryScan() throws HygieiaException {
-        Dashboard expected = makeTeamDashboard("template", "dashboardtitle", "appName", "someuser","","", "comp1","comp2");
-        ObjectId objectId = ObjectId.get();
-        expected.setId(objectId);
-        DashboardRemoteRequest request = makeDashboardRemoteRequest("template", "dashboardtitle", "appName", "comp", "someuser", null, "team", "", "");
+    public void remoteUpdateNonExisting() throws IOException {
+        DashboardRemoteRequest request = getRemoteRequest("./dashboardRemoteRequests/Remote-Request-Base.json");
+        request.getMetaData().setTitle("missingDashboard");
+
+        Throwable t = new Throwable();
+        RuntimeException excep = new RuntimeException("Dashboard " + request.getMetaData().getTitle() +  " does not exist.", t);
+
+        try {
+            dashboardRemoteService.remoteCreate(request, true);
+            fail("Should throw RuntimeException");
+        } catch(Exception e) {
+            assertEquals(excep.getMessage(), e.getMessage());
+        }
+    }
+    @Test
+    public void remoteUpdateLibraryScan() throws HygieiaException, IOException {
+        DashboardRemoteRequest request = getRemoteRequest("./dashboardRemoteRequests/Remote-Request-Base.json");
+        request.getMetaData().setTitle("TestSSA");
         List<DashboardRemoteRequest.LibraryScanEntry> entries = new ArrayList<>();
         DashboardRemoteRequest.LibraryScanEntry validLibraryScan = new DashboardRemoteRequest.LibraryScanEntry();
 
@@ -320,73 +268,33 @@ public class DashboardRemoteServiceTest {
         options.put("instanceUrl", "http://test.com");
         validLibraryScan.setOptions(options);
         entries.add(validLibraryScan);
+        options = new HashMap();
+        options.put("applicationId", "applicationIdTest1");
+        options.put("applicationName", "testApplicationName1");
+        options.put("publicId", "1234561");
+        options.put("instanceUrl", "http://test1.com");
+        validLibraryScan.setOptions(options);
+        entries.add(validLibraryScan);
+
         request.setLibraryScanEntries(entries);
-        Component componentTest = new Component();
 
-
-        Map<CollectorType, List<CollectorItem>> collectorItems = new HashMap<>();
-
-        List<CollectorItem> collectorItemsList = new ArrayList<>();
-        collectorItemsList.add( makeCollectorItem());
-        collectorItems.put(CollectorType.Test ,collectorItemsList);
-        componentTest.setCollectorItems(collectorItems);
-
-        when(componentRepository.findOne(any(ObjectId.class))).thenReturn(componentTest);
-        when(userInfoService.isUserValid(request.getMetaData().getOwner().getUsername(), request.getMetaData().getOwner().getAuthType())).thenReturn(true);
-        when(dashboardRepository.findByTitle(request.getMetaData().getTitle())).thenReturn(new ArrayList<>());
-        when(dashboardService.create(Matchers.any(Dashboard.class))).thenReturn(expected);
-        when(dashboardService.get(objectId)).thenReturn(expected);
-
-        List<Collector> collectors = new ArrayList<>();
-        Collector nexusIQCollector = makeCollector("NexusIQ", CollectorType.LibraryPolicy);
-        Map uniqueFields = new HashMap();
-        uniqueFields.put("applicationName", "");
-        uniqueFields.put("instanceUrl", "");
-        nexusIQCollector.setUniqueFields(uniqueFields);
-
-        Map allFields = new HashMap();
-        allFields.put("applicationId", "");
-        allFields.put("applicationName", "");
-        allFields.put("publicId", "");
-        allFields.put("instanceUrl", "");
-        nexusIQCollector.setAllFields(allFields);
-
-        collectors.add(nexusIQCollector);
-
-        when( collectorRepository.findByCollectorTypeAndName(validLibraryScan.getType(), validLibraryScan.getToolName()) ).thenReturn(collectors);
-
-        CollectorItem item = makeCollectorItem();
-
-        when(  collectorService.createCollectorItemSelectOptions(Matchers.any(CollectorItem.class), Matchers.any(Map.class), Matchers.any(Map.class) ) ).thenReturn(item);
-
-        assertThat(dashboardRemoteService.remoteCreate(request, false), is(expected));
+        dashboardRemoteService.remoteCreate(request, true);
+        List<Dashboard> dashboard = dashboardService.getByTitle("TestSSA");
+        Component component = componentRepository.findOne(dashboard.get(0).getApplication().getComponents().get(0).getId());
+        assertEquals(2, component.getCollectorItems().get(CollectorType.LibraryPolicy).size());
+        assertNotNull(component.getCollectorItems().get(CollectorType.CodeQuality));
+        assertNotNull(component.getCollectorItems().get(CollectorType.Test));
+        assertNotNull(component.getCollectorItems().get(CollectorType.StaticSecurityScan));
 
     }
-    private Dashboard makeTeamDashboard(String template, String title, String appName, String owner,String configItemBusServName,String configItemBusAppName, String... compNames) {
-        Application app = new Application(appName);
-        for (String compName : compNames) {
-            app.addComponent(new Component(compName));
-        }
-        List<String> activeWidgets = new ArrayList<>();
-        return new Dashboard(template, title, app, new Owner(owner, AuthType.STANDARD), DashboardType.Team, configItemBusServName, configItemBusAppName,activeWidgets, false, ScoreDisplayType.HEADER);
+
+    private String getExpectedJSON(String path) throws IOException {
+        URL fileUrl = Resources.getResource(path);
+        return IOUtils.toString(fileUrl);
+    }
+    private DashboardRemoteRequest getRemoteRequest (String fileName) throws IOException {
+        Gson gson = GsonUtil.getGson();
+        return gson.fromJson(getExpectedJSON(fileName), new TypeToken<DashboardRemoteRequest>(){}.getType());
     }
 
-    private Collector makeCollector(String name, CollectorType type) {
-        Collector collector = new Collector();
-        collector.setId(ObjectId.get());
-        collector.setName(name);
-        collector.setCollectorType(type);
-        collector.setEnabled(true);
-        collector.setOnline(true);
-        collector.setLastExecuted(System.currentTimeMillis());
-        return collector;
-    }
-
-    private CollectorItem makeCollectorItem() {
-        CollectorItem item = new CollectorItem();
-        item.setCollectorId(new ObjectId());
-        item.setId(new ObjectId());
-        item.setEnabled(true);
-        return item;
-    }
 }

--- a/api/src/test/java/com/capitalone/dashboard/service/DashboardRemoteServiceTest.java
+++ b/api/src/test/java/com/capitalone/dashboard/service/DashboardRemoteServiceTest.java
@@ -83,7 +83,13 @@ public class DashboardRemoteServiceTest {
         Component component = componentRepository.findOne(dashboard.get(0).getApplication().getComponents().get(0).getId());
         assertEquals(2, component.getCollectorItems().get(CollectorType.SCM).size());
     }
-
+    @Test
+    public void remoteCreateEmptyEntry() throws IOException, HygieiaException {
+        DashboardRemoteRequest request = getRemoteRequest("./dashboardRemoteRequests/Remote-Request-Base.json");
+        Dashboard dashboard = dashboardRemoteService.remoteCreate(request, false);
+        assertNotNull(dashboard);
+        assertEquals(request.getMetaData().getTitle(),dashboard.getTitle());
+    }
     @Test
     public void remoteCreateInvalidUser() throws IOException {
         DashboardRemoteRequest request = getRemoteRequest("./dashboardRemoteRequests/0-Remote-Update-Repo.json");
@@ -296,5 +302,4 @@ public class DashboardRemoteServiceTest {
         Gson gson = GsonUtil.getGson();
         return gson.fromJson(getExpectedJSON(fileName), new TypeToken<DashboardRemoteRequest>(){}.getType());
     }
-
 }

--- a/api/src/test/java/com/capitalone/dashboard/util/TestUtil.java
+++ b/api/src/test/java/com/capitalone/dashboard/util/TestUtil.java
@@ -1,11 +1,27 @@
 package com.capitalone.dashboard.util;
 import com.capitalone.dashboard.mapper.CustomObjectMapper;
+import com.capitalone.dashboard.model.Collector;
+import com.capitalone.dashboard.model.CollectorItem;
+import com.capitalone.dashboard.model.Component;
+import com.capitalone.dashboard.model.Dashboard;
+import com.capitalone.dashboard.model.UserInfo;
+import com.capitalone.dashboard.repository.CollectorItemRepository;
+import com.capitalone.dashboard.repository.CollectorRepository;
+import com.capitalone.dashboard.repository.ComponentRepository;
+import com.capitalone.dashboard.repository.DashboardRepository;
+import com.capitalone.dashboard.repository.UserInfoRepository;
+import com.capitalone.dashboard.testutil.GsonUtil;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.io.Resources;
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+import org.apache.commons.io.IOUtils;
 import org.springframework.http.MediaType;
 
 import java.io.IOException;
 import java.nio.charset.Charset;
+import java.util.List;
 
 import static org.springframework.http.MediaType.*;
 
@@ -17,5 +33,37 @@ public class TestUtil {
         ObjectMapper mapper = new CustomObjectMapper();
         mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
         return mapper.writeValueAsBytes(object);
+    }
+
+    public static void loadDashBoard(DashboardRepository dashboardRepository) throws IOException {
+        Gson gson = GsonUtil.getGson();
+        String json = IOUtils.toString(Resources.getResource("./dashboard/dashboard.json"));
+        Dashboard dashboard = gson.fromJson(json, Dashboard.class);
+        dashboardRepository.save(dashboard);
+    }
+    public static void loadUserInfo(UserInfoRepository userInfoRepository) throws IOException {
+        Gson gson = GsonUtil.getGson();
+        String json = IOUtils.toString(Resources.getResource("./userInfo/user.json"));
+        UserInfo userInfo = gson.fromJson(json, UserInfo.class);
+        userInfoRepository.save(userInfo);
+    }
+    public static void loadCollector(CollectorRepository collectorRepository) throws IOException {
+        Gson gson = GsonUtil.getGson();
+        String json = IOUtils.toString(Resources.getResource("./collectors/coll.json"));
+        List<Collector> collector = gson.fromJson(json, new TypeToken<List<Collector>>() {
+        }.getType());
+        collectorRepository.save(collector);
+    }
+    public static void loadComponent(ComponentRepository componentRepository) throws IOException {
+        Gson gson = GsonUtil.getGson();
+        String json = IOUtils.toString(Resources.getResource("./component/component.json"));
+        Component component = gson.fromJson(json, Component.class);
+        componentRepository.save(component);
+    }
+    public static void loadCollectorItems(CollectorItemRepository collectorItemRepository) throws IOException {
+        Gson gson = GsonUtil.getGson();
+        String json = IOUtils.toString(Resources.getResource("./collector_items/items.json"));
+        List<CollectorItem> collectorItem = gson.fromJson(json, new TypeToken<List<CollectorItem>>(){}.getType());
+        collectorItemRepository.save(collectorItem);
     }
 }

--- a/api/src/test/resources/collector_items/items.json
+++ b/api/src/test/resources/collector_items/items.json
@@ -1,0 +1,501 @@
+[
+  {
+    "description": "Registered by Remote Call.",
+    "enabled": true,
+    "errors": [],
+    "pushed": false,
+    "collectorId": {
+      "timestamp": 1456084265,
+      "machineIdentifier": 8366972,
+      "processIdentifier": 26815,
+      "counter": 14369292
+    },
+    "lastUpdated": 1516222021186,
+    "options": {
+      "branch": "master",
+      "url": "https://mygithub.com/compliance-scenario/0-new-repo"
+    },
+    "id": "5a4e524333ec296b81c3936f"
+  },
+  {
+    "description": "card-customer-service:card-cust-service",
+    "enabled": true,
+    "errors": [],
+    "pushed": false,
+    "collectorId": "5ad5f605c23b391cfa1c01a4",
+    "lastUpdated": 1523562528850,
+    "options": {
+      "applicationType": null,
+      "reportUrl": "https://appsec.com/StaticSecurityAnalysis",
+      "applicationID": [
+        "TestBusServ"
+      ],
+      "projectName": "cust-service",
+      "applicationName": "customer-service",
+      "instanceUrl": "https://appsec.com"
+    },
+    "id": "5b4e524333ec296b81c3935f"
+  },
+  {
+    "description": "TestAudit",
+    "enabled": false,
+    "errors": [],
+    "pushed": false,
+    "collectorId": {
+      "timestamp": 1515645558,
+      "machineIdentifier": 4693261,
+      "processIdentifier": 6916,
+      "counter": 3010175
+    },
+    "lastUpdated": 0,
+    "options": {
+      "dashboardId": "5a56eae1479d0d1b042dee87"
+    },
+    "id": {
+      "timestamp": 1515646073,
+      "machineIdentifier": 4693261,
+      "processIdentifier": 6916,
+      "counter": 3010194
+    }
+  },
+  {
+    "description": "Registered by Remote Call.",
+    "enabled": true,
+    "errors": [],
+    "pushed": false,
+    "collectorId": {
+      "timestamp": 1456084265,
+      "machineIdentifier": 8366972,
+      "processIdentifier": 26815,
+      "counter": 14369292
+    },
+    "lastUpdated": 1516222021186,
+    "options": {
+      "branch": "master",
+      "url": "https://mygithub.com/compliance-scenario/0-new-repo"
+    },
+    "id": "5a4e524333ec296b81c3936f"
+  },
+  {
+    "description": "Registered by Remote Call.",
+    "enabled": true,
+    "errors": [],
+    "pushed": false,
+    "collectorId": {
+      "timestamp": 1456084265,
+      "machineIdentifier": 8366972,
+      "processIdentifier": 26815,
+      "counter": 14369292
+    },
+    "lastUpdated": 1516222021942,
+    "options": {
+      "branch": "master",
+      "url": "https://mygithub.com/compliance-scenario/1-direct-commit"
+    },
+    "id": {
+      "timestamp": 1515082351,
+      "machineIdentifier": 3402793,
+      "processIdentifier": 27521,
+      "counter": 12817252
+    }
+  },
+  {
+    "description": "Registered by Remote Call.",
+    "enabled": true,
+    "errors": [],
+    "pushed": false,
+    "collectorId": {
+      "timestamp": 1456084265,
+      "machineIdentifier": 8366972,
+      "processIdentifier": 26815,
+      "counter": 14369292
+    },
+    "lastUpdated": 1516222022525,
+    "options": {
+      "branch": "master",
+      "url": "https://mygithub.com/compliance-scenario/2-unreviewed-merge"
+    },
+    "id": {
+      "timestamp": 1515082392,
+      "machineIdentifier": 3402793,
+      "processIdentifier": 27521,
+      "counter": 12817258
+    }
+  },
+  {
+    "description": "Registered by Remote Call.",
+    "enabled": true,
+    "errors": [],
+    "pushed": false,
+    "collectorId": {
+      "timestamp": 1456084265,
+      "machineIdentifier": 8366972,
+      "processIdentifier": 26815,
+      "counter": 14369292
+    },
+    "lastUpdated": 1516222023061,
+    "options": {
+      "branch": "master",
+      "url": "https://mygithub.com/compliance-scenario/3-github-comment-merge"
+    },
+    "id": {
+      "timestamp": 1515082428,
+      "machineIdentifier": 3402793,
+      "processIdentifier": 27521,
+      "counter": 12817263
+    }
+  },
+  {
+    "description": "Registered by Remote Call.",
+    "enabled": true,
+    "errors": [],
+    "pushed": false,
+    "collectorId": {
+      "timestamp": 1456084265,
+      "machineIdentifier": 8366972,
+      "processIdentifier": 26815,
+      "counter": 14369292
+    },
+    "lastUpdated": 1516222023498,
+    "options": {
+      "branch": "master",
+      "url": "https://mygithub.com/compliance-scenario/4-github-review-merge"
+    },
+    "id": {
+      "timestamp": 1515082480,
+      "machineIdentifier": 3402793,
+      "processIdentifier": 27521,
+      "counter": 12817268
+    }
+  },
+  {
+    "description": "Registered by Remote Call.",
+    "enabled": true,
+    "errors": [],
+    "pushed": false,
+    "collectorId": {
+      "timestamp": 1456084265,
+      "machineIdentifier": 8366972,
+      "processIdentifier": 26815,
+      "counter": 14369292
+    },
+    "lastUpdated": 1516222024012,
+    "options": {
+      "branch": "master",
+      "url": "https://mygithub.com/compliance-scenario/5-lgtm-self-merge"
+    },
+    "id": {
+      "timestamp": 1515082524,
+      "machineIdentifier": 3402793,
+      "processIdentifier": 27521,
+      "counter": 12817274
+    }
+  },
+  {
+    "description": "Registered by Remote Call.",
+    "enabled": true,
+    "errors": [],
+    "pushed": false,
+    "collectorId": {
+      "timestamp": 1456084265,
+      "machineIdentifier": 8366972,
+      "processIdentifier": 26815,
+      "counter": 14369292
+    },
+    "lastUpdated": 1516222024449,
+    "options": {
+      "branch": "master",
+      "url": "https://mygithub.com/compliance-scenario/6-lgtm-merge"
+    },
+    "id": {
+      "timestamp": 1515082558,
+      "machineIdentifier": 3402793,
+      "processIdentifier": 27521,
+      "counter": 12817279
+    }
+  },
+  {
+    "description": "Registered by Remote Call.",
+    "enabled": true,
+    "errors": [
+      {
+        "errorCode": "-1",
+        "errorMessage": "Error in GraphQL query:[{\"path\":[\"repository\"],\"locations\":[{\"line\":2,\"column\":3}],\"message\":\"Could not resolve to a Repository with the name \u00277-private-repo\u0027.\",\"type\":\"NOT_FOUND\"}]",
+        "timestamp": 1516222002518
+      },
+      {
+        "errorCode": "-1",
+        "errorMessage": "Error in GraphQL query:[{\"path\":[\"repository\"],\"locations\":[{\"line\":2,\"column\":3}],\"message\":\"Could not resolve to a Repository with the name \u00277-private-repo\u0027.\",\"type\":\"NOT_FOUND\"}]",
+        "timestamp": 1516222020507
+      }
+    ],
+    "pushed": false,
+    "collectorId": {
+      "timestamp": 1456084265,
+      "machineIdentifier": 8366972,
+      "processIdentifier": 26815,
+      "counter": 14369292
+    },
+    "lastUpdated": 0,
+    "options": {
+      "branch": "master",
+      "url": "https://mygithub.com/compliance-scenario/7-private-repo"
+    },
+    "id": {
+      "timestamp": 1515082653,
+      "machineIdentifier": 3402793,
+      "processIdentifier": 27521,
+      "counter": 12817284
+    }
+  },
+  {
+    "enabled": true,
+    "errors": [],
+    "pushed": false,
+    "collectorId": {
+      "timestamp": 1456084265,
+      "machineIdentifier": 8366972,
+      "processIdentifier": 26815,
+      "counter": 14369292
+    },
+    "lastUpdated": 1516222024902,
+    "options": {
+      "password": "",
+      "scm": "Github",
+      "branch": "master",
+      "userID": "",
+      "url": "https://mygithub.com/Devopscode/NormalMerge"
+    },
+    "id": {
+      "timestamp": 1515082910,
+      "machineIdentifier": 3402793,
+      "processIdentifier": 27521,
+      "counter": 12817291
+    }
+  },
+  {
+    "enabled": true,
+    "errors": [],
+    "pushed": false,
+    "collectorId": {
+      "timestamp": 1456084265,
+      "machineIdentifier": 8366972,
+      "processIdentifier": 26815,
+      "counter": 14369292
+    },
+    "lastUpdated": 1516222025333,
+    "options": {
+      "password": "",
+      "scm": "Github",
+      "branch": "master",
+      "userID": "",
+      "url": "https://mygithub.com/Devopscode/SquashMerge"
+    },
+    "id": {
+      "timestamp": 1515082938,
+      "machineIdentifier": 3402793,
+      "processIdentifier": 27521,
+      "counter": 12817296
+    }
+  },
+  {
+    "enabled": true,
+    "errors": [],
+    "pushed": false,
+    "collectorId": {
+      "timestamp": 1456084265,
+      "machineIdentifier": 8366972,
+      "processIdentifier": 26815,
+      "counter": 14369292
+    },
+    "lastUpdated": 1516222025759,
+    "options": {
+      "password": "",
+      "scm": "Github",
+      "branch": "master",
+      "userID": "",
+      "url": "https://mygithub.com/Devopscode/RebaseMerge"
+    },
+    "id": {
+      "timestamp": 1515082968,
+      "machineIdentifier": 3402793,
+      "processIdentifier": 27521,
+      "counter": 12817301
+    }
+  },
+  {
+    "enabled": true,
+    "errors": [],
+    "pushed": false,
+    "collectorId": {
+      "timestamp": 1456084265,
+      "machineIdentifier": 8366972,
+      "processIdentifier": 26815,
+      "counter": 14369292
+    },
+    "lastUpdated": 1516222026134,
+    "options": {
+      "password": "",
+      "scm": "Github",
+      "branch": "master",
+      "userID": "",
+      "url": "https://mygithub.com/Devopscode/OpenForkPr"
+    },
+    "id": {
+      "timestamp": 1515082998,
+      "machineIdentifier": 3402793,
+      "processIdentifier": 27521,
+      "counter": 12817306
+    }
+  },
+  {
+    "enabled": true,
+    "errors": [],
+    "pushed": false,
+    "collectorId": {
+      "timestamp": 1456084265,
+      "machineIdentifier": 8366972,
+      "processIdentifier": 26815,
+      "counter": 14369292
+    },
+    "lastUpdated": 1516222026476,
+    "options": {
+      "password": "",
+      "scm": "Github",
+      "branch": "master",
+      "userID": "",
+      "url": "https://mygithub.com/Devopscode/OpenBranchPr"
+    },
+    "id": {
+      "timestamp": 1515083026,
+      "machineIdentifier": 3402793,
+      "processIdentifier": 27521,
+      "counter": 12817311
+    }
+  },
+  {
+    "id": "5a678a032b7af20c95e7b146",
+    "enabled": true,
+    "errors": [],
+    "pushed": false,
+    "collectorId": "56ca15297fab7c68bfdb420c",
+    "lastUpdated": 1516735761179,
+    "options": {
+      "password": "",
+      "scm": "Github",
+      "branch": "master",
+      "userID": "",
+      "url": "https://mygithub.com/Devopscode/MultipleAuthorsLGTM"
+    }
+  },
+  {
+    "id": "5a4e524333ec296b81c3935f",
+    "enabled": true,
+    "errors": [],
+    "pushed": false,
+    "collectorId": "56ca15297fab7c68bfdb420c",
+    "lastUpdated": 1517029042023,
+    "options": {
+      "password": "",
+      "scm": "Github",
+      "branch": "master",
+      "userID": "",
+      "url": "https://mygithub.com/Devopscode/MultipleAuthorsGHR"
+    }
+  },
+   {
+    "id": "5ad5f605c23b391cfa1c01a4",
+    "description": "myapplication:mycomponent",
+    "enabled": false,
+    "errors": [],
+    "pushed": false,
+    "collectorId": "5af9ed53cba7165e8cc1069e",
+    "lastUpdated": 1524190250247,
+    "options": {
+      "applicationType": null,
+      "componentName": "mycomponent",
+      "applicationID": [
+        "SOMEAPPLICATION"
+      ],
+      "applicationName": "account-my-information",
+      "instanceUrl": "https://scan.com"
+    }
+  },
+  {
+    "id": "56e301107fab7c3ec3c43397",
+    "enabled": true,
+    "errors": [],
+    "pushed": false,
+    "collectorId": "56ca15297fab7c68bfdb420c",
+    "lastUpdated": 1528709104212,
+    "options": {
+      "scm": "Github",
+      "branch": "develop",
+      "url": "https://mygithub.com/TechOriginations/openupf"
+    }
+  },
+  {
+    "id": "56e5919d7fab7c0244e33341",
+    "description": "openupf service parent",
+    "niceName": "HomeLoan",
+    "enabled": true,
+    "errors": [],
+    "pushed": true,
+    "collectorId": "56cb5bde7fab7c548551410e",
+    "lastUpdated": 1460387608894,
+    "options": {
+      "projectName": "openupf service parent",
+      "projectId": "111955",
+      "instanceUrl": "http://mysonar.com:11300/sonar"
+    }
+  },
+  {
+    "id": "57f2a0193b55670a9e06d63a",
+    "description": "TEST-UI",
+    "niceName": "TEST",
+    "enabled": true,
+    "errors": [],
+    "pushed": true,
+    "collectorId": "56df29df7fab7c3ec3c432ea",
+    "lastUpdated": 1513106044147,
+    "options": {
+      "jobName": "TEST-UI",
+      "jobUrl": "https://myjenkins.com/myjenkins/job/TEST-UI/",
+      "instanceUrl": "https://myjenkins.com/myjenkins/",
+      "applicationID": [
+        "TestBusServ"
+      ]
+    }
+  },
+  {
+    "id": "5b7b33d6b2ea1a4c58a61a2d",
+    "enabled": true,
+    "errors": [],
+    "pushed": false,
+    "collectorId": "56ca15297fab7c68bfdb420c",
+    "lastUpdated": 1534804146907,
+    "options": {
+      "password": "",
+      "personalAccessToken": "",
+      "branch": "master",
+      "userID": "",
+      "url": "https://mygithub.com/Devopscode/HandleMisleadingSingleParentCommit"
+    }
+  },
+  {
+    "id": "5b87001e60bd8d3c47853f3d",
+    "_class": "com.capitalone.dashboard.model.GitHubRepo",
+    "enabled": true,
+    "errors": [],
+    "pushed": false,
+    "collectorId": "56ca15297fab7c68bfdb420c",
+    "lastUpdated": 1535574536694,
+    "options": {
+      "password": "",
+      "personalAccessToken": "",
+      "branch": "master",
+      "userID": "",
+      "url": "https://mygithub.com/Devopscode/NewPrOldCommit"
+    }
+  }
+]

--- a/api/src/test/resources/collectors/coll.json
+++ b/api/src/test/resources/collectors/coll.json
@@ -1,0 +1,216 @@
+[
+  {
+    "id" : "56cb5bde7fab7c548551410e",
+    "sonarVersions" : [
+      4.3,
+      5.3,
+      5.6,
+      6.7,
+      6.7
+    ],
+    "sonarMetrics" : [
+      "ncloc,line_coverage,violations,critical_violations,major_violations,blocker_violations,violations_density,sqale_index,test_success_density,test_failures,test_errors,tests",
+      "ncloc,line_coverage,violations,critical_violations,major_violations,blocker_violations,violations_density,sqale_index,test_success_density,test_failures,test_errors,tests",
+      "ncloc,violations,new_vulnerabilities,critical_violations,major_violations,blocker_violations,tests,test_success_density,test_errors,test_failures,coverage,line_coverage,sqale_index,alert_status,quality_gate_details",
+      "ncloc,violations,new_vulnerabilities,critical_violations,major_violations,blocker_violations,tests,test_success_density,test_errors,test_failures,coverage,line_coverage,sqale_index,alert_status,quality_gate_details",
+      "ncloc,violations,new_vulnerabilities,critical_violations,major_violations,blocker_violations,tests,test_success_density,test_errors,test_failures,coverage,line_coverage,sqale_index,alert_status,quality_gate_details"
+    ],
+    "name" : "Sonar",
+    "collectorType" : "CodeQuality",
+    "enabled" : true,
+    "online" : true,
+    "errors" : [
+    ],
+    "uniqueFields" : {
+      "projectName" : "",
+      "instanceUrl" : ""
+    },
+    "allFields" : {
+      "projectName" : "",
+      "projectId" : "",
+      "instanceUrl" : ""
+    },
+    "lastExecuted" : 1528709375907,
+    "searchFields" : [
+      "description"
+    ]
+  },
+  {
+    "id": "5ad5f605c23b391cfa1c01a4",
+    "name": "StaticSecurityScanCollector",
+    "collectorType": "StaticSecurityScan",
+    "enabled": true,
+    "online": false,
+    "errors": [],
+    "uniqueFields": {
+      "applicationID": "",
+      "projectName": "",
+      "applicationName": "",
+      "instanceUrl": ""
+    },
+    "allFields": {
+      "applicationType": "",
+      "reportUrl": "",
+      "applicationID": "",
+      "projectName": "",
+      "applicationName": "",
+      "instanceUrl": ""
+    },
+    "lastExecuted": 1523562531181
+  },
+  {
+    "id": "5af9ed53cba7165e8cc1069e",
+    "eratocodeServers": [
+      "https://scan.com"
+    ],
+    "niceNames": [],
+    "name": "OSSCollector",
+    "collectorType": "LibraryPolicy",
+    "enabled": true,
+    "online": false,
+    "errors": [],
+    "uniqueFields": {
+      "componentName": "",
+      "applicationName": "",
+      "instanceUrl": ""
+    },
+    "allFields": {
+      "applicationType": "",
+      "componentName": "",
+      "applicationID": "",
+      "applicationName": "",
+      "instanceUrl": ""
+    },
+    "lastExecuted": 1518986735128,
+    "searchFields": [
+      "description"
+    ]
+  },
+  {
+    "id" : "5a9efef85bcf7d3eb7d4bf85",
+    "name" : "JenkinsCucumberTest",
+    "collectorType" : "Test",
+    "enabled" : true,
+    "online" : true,
+    "errors" : [],
+    "uniqueFields" : {
+      "jobName" : "",
+      "jobUrl" : "",
+      "instanceUrl" : ""
+    },
+    "allFields" : {
+      "jobName" : "",
+      "jobUrl" : "",
+      "instanceUrl" : ""
+    },
+    "lastExecuted" : 1523388360308,
+    "searchFields" : [
+      "description"
+    ]
+  },
+  {
+    "id" : "56df29df7fab7c3ec3c432ea",
+    "name" : "JenkinsCucumberTest",
+    "collectorType" : "Test",
+    "enabled" : true,
+    "online" : true,
+    "errors" : [],
+    "uniqueFields" : {
+      "jobName" : "",
+      "jobUrl" : "",
+      "instanceUrl" : ""
+    },
+    "allFields" : {
+      "jobName" : "",
+      "jobUrl" : "",
+      "instanceUrl" : ""
+    },
+    "lastExecuted" : 1522833838069,
+    "searchFields" : [
+      "description"
+    ]
+  },
+  {
+    "id" : "597b9b0633681a4f1834646d",
+    "jobUrl" : "",
+    "name" : "JenkinsASRTest",
+    "collectorType" : "Test",
+    "enabled" : true,
+    "online" : false,
+    "errors" : [],
+    "uniqueFields" : {},
+    "allFields" : {},
+    "lastExecuted" : 1501381330234
+  },
+  {
+    "id" : "56ca15297fab7c68bfdb420c",
+    "name" : "GitHub",
+    "collectorType" : "SCM",
+    "enabled" : true,
+    "online" : true,
+    "errors" : [
+    ],
+    "uniqueFields" : {
+      "branch" : "",
+      "url" : ""
+    },
+    "allFields" : {
+      "password" : "",
+      "personalAccessToken" : "",
+      "branch" : "",
+      "userID" : "",
+      "url" : ""
+    },
+    "lastExecuted" : 1528709433703,
+    "searchFields" : [
+      "description"
+    ]
+  },
+  {
+    "id" : "56ca5b387fab7c05d45a20ce",
+    "name" : "Hudson",
+    "collectorType" : "Build",
+    "enabled" : true,
+    "online" : true,
+    "errors" : [],
+    "uniqueFields" : {
+      "jobName" : "",
+      "jobUrl" : ""
+    },
+    "allFields" : {
+      "jobName" : "",
+      "jobUrl" : "",
+      "instanceUrl" : ""
+    },
+    "lastExecuted" : 1546543433357,
+    "searchFields" : [
+      "options.jobName",
+      "niceName"
+    ]
+  },
+  {
+    "id" : "596253004df5900cd08d1123",
+    "nexusIQServers" : [
+      "https://testNexusIQ.com"
+    ],
+    "name" : "NexusIQ",
+    "collectorType" : "LibraryPolicy",
+    "enabled" : true,
+    "online" : true,
+    "errors" : [],
+    "uniqueFields" : {
+      "applicationName" : "",
+      "instanceUrl" : ""
+    },
+    "allFields" : {
+      "applicationId" : "",
+      "applicationName" : "",
+      "publicId" : "",
+      "instanceUrl" : ""
+    },
+    "lastExecuted" : 1525174215134,
+    "searchFields" : [
+      "description"
+    ]
+  }
+]

--- a/api/src/test/resources/component/component.json
+++ b/api/src/test/resources/component/component.json
@@ -1,0 +1,100 @@
+{
+  "name": "TestAudit",
+  "id": "57f29d143b55670a9e06d624",
+  "collectorItems": {
+    "SCM": [
+      {
+        "id":"56e301107fab7c3ec3c43397",
+        "enabled": true,
+        "errors": [],
+        "pushed": false,
+        "collectorId": "56ca15297fab7c68bfdb420c",
+        "lastUpdated": 0,
+        "options": {
+          "password": "",
+          "scm": "Github",
+          "branch": "master",
+          "userID": "",
+          "url": "https://mygithub.com/one/two"
+        }
+      }
+    ],
+    "StaticSecurityScan": [
+      {
+        "enabled": true,
+        "errors": [],
+        "pushed": false,
+        "collectorId": "5ad5f605c23b391cfa1c01a4",
+        "lastUpdated": 1522773350945,
+        "options": {
+          "applicationType": "Desktop",
+          "reportUrl": "https://appsec.com",
+          "applicationID": [
+            "TestBusServ"
+          ],
+          "projectName": "cust-service",
+          "applicationName": "customer-service",
+          "instanceUrl": "https://appsec.com"
+        },
+        "id": "5b4e524333ec296b81c3935f"
+      }
+    ],
+    "LibraryPolicy" : [
+      {
+        "id": "5af9ed53cba7165e8cc1069e",
+        "description": "myapplication:mycomponent",
+        "enabled": false,
+        "errors": [],
+        "pushed": false,
+        "collectorId": "5ad4c71841a34c9696cdfa2e",
+        "lastUpdated": 1524190250247,
+        "options": {
+          "applicationType": null,
+          "componentName": "mycomponent",
+          "applicationID": [
+            "SOMEAPPLICATION"
+          ],
+          "applicationName": "account-my-information",
+          "instanceUrl": "https://scan.com"
+        }
+      }
+    ],
+    "Test" : [
+      {
+        "id" : "57f2a0193b55670a9e06d63a",
+        "description" : "Functional-SLATE",
+        "niceName" : "ABCD",
+        "enabled" : true,
+        "errors" : [
+        ],
+        "pushed" : true,
+        "collectorId" : "56df29df7fab7c3ec3c432ea",
+        "lastUpdated" : 1513106044147,
+        "options" : {
+          "jobName" : "Functional-SLATE",
+          "jobUrl" : "https://myjenkins.com/jenkins/job/Functional-SLATE/",
+          "instanceUrl" : "https://myjenkins.com/jenkins/"
+        }
+      }
+    ],
+    "CodeQuality" : [
+      {
+        "id" : "56e5919d7fab7c0244e33341",
+        "description" : "service parent",
+        "enabled" : true,
+        "errors" : [
+
+        ],
+        "pushed" : false,
+        "collectorId" : "56cb5bde7fab7c548551410e",
+        "lastUpdated" : 0,
+        "options" : {
+          "projectName" : "service parent",
+          "projectId" : "124466",
+          "instanceUrl" : "https://sonar.com"
+        }
+      }
+    ]
+  }
+
+}

--- a/api/src/test/resources/dashboard/dashboard.json
+++ b/api/src/test/resources/dashboard/dashboard.json
@@ -1,0 +1,87 @@
+{
+  "template": "widgets",
+  "title": "TestSSA",
+  "widgets": [
+    {
+      "id": {
+        "timestamp": 1515646073,
+        "machineIdentifier": 4693261,
+        "processIdentifier": 6916,
+        "counter": 3010193
+      },
+      "name": "codeanalysis",
+      "componentId": "57f29d143b55670a9e06d624",
+      "options": {
+        "id": "codeanalysis0"
+      }
+    },
+    {
+      "name" : "feature",
+      "componentId" : "57f29d143b55670a9e06d624",
+      "options" : {
+        "sprintType" : "kanban",
+        "featureTool" : "Jira",
+        "showStatus" : {
+          "kanban" : true,
+          "scrum" : false
+        },
+        "id" : "feature0",
+        "estimateMetricType" : "storypoints",
+        "listType" : "epics",
+        "teamId" : "Team:26967234"
+      }
+    },
+    {
+      "id": {
+        "timestamp": 1515646073,
+        "machineIdentifier": 4693261,
+        "processIdentifier": 6916,
+        "counter": 3010193
+      },
+      "name": "repo",
+      "componentId": "57f29d143b55670a9e06d624" ,
+      "options": {
+        "password": "",
+        "id": "repo0",
+        "scm": {
+          "name": "GitHub",
+          "value": "GitHub"
+        },
+        "branch": "master",
+        "userID": "",
+        "url": "https://mygithub.com/compliance-scenario/6-lgtm-merge"
+      }
+    }
+  ],
+  "owners": [
+    {
+      "username": "topopal",
+      "authType": "STANDARD"
+    }
+  ],
+  "type": "Team",
+  "application": {
+    "name": "TestAudit",
+    "components": [
+      {
+        "ref" : "components",
+        "id" : "57f29d143b55670a9e06d624"
+      }
+    ]
+  },
+  "validServiceName": true,
+  "validAppName": true,
+  "remoteCreated": false,
+  "configurationItemBusServName": "TestBusServ",
+  "configurationItemBusAppName": "confItem",
+  "activeWidgets": [
+    "repo"
+  ],
+  "errorCode": 0,
+  "id": {
+    "timestamp": 1515645665,
+    "machineIdentifier": 4693261,
+    "processIdentifier": 6916,
+    "counter": 3010183
+  }
+}

--- a/api/src/test/resources/dashboardRemoteRequests/0-Remote-Update-Repo.json
+++ b/api/src/test/resources/dashboardRemoteRequests/0-Remote-Update-Repo.json
@@ -1,0 +1,33 @@
+{
+  "metaData":
+  {
+    "applicationName":"TestAudit",
+    "componentName":"TestAudit",
+    "owner":
+    {
+      "authType":"STANDARD",
+      "username":"topopal"
+    },
+    "template":"CapOne",
+    "title":"TestSSA",
+    "type":"Team"
+  },
+  "codeRepoEntries":[
+    {
+      "toolName":"GitHub",
+      "description":"Registered by Test.",
+      "options": {
+        "branch": "master",
+        "url": "https://mygithub.com/TestRepo/Repo1"
+      }
+    },
+    {
+      "toolName": "GitHub",
+      "description": "Registered by Test.",
+      "options": {
+        "branch": "master",
+        "url": "https://mygithub.com/TestRepo/Repo2"
+      }
+    }
+  ]
+}

--- a/api/src/test/resources/dashboardRemoteRequests/Remote-Request-Base.json
+++ b/api/src/test/resources/dashboardRemoteRequests/Remote-Request-Base.json
@@ -1,0 +1,15 @@
+{
+  "metaData":
+  {
+    "applicationName":"test1",
+    "componentName":"test1",
+    "owner":
+    {
+      "authType":"STANDARD",
+      "username":"topopal"
+    },
+    "template":"CapOne",
+    "title":"testTitle",
+    "type":"Team"
+  }
+}

--- a/api/src/test/resources/userInfo/user.json
+++ b/api/src/test/resources/userInfo/user.json
@@ -1,0 +1,12 @@
+{
+  "username" : "topopal",
+  "authorities" : [
+    "ROLE_USER"
+  ],
+  "authType" : "STANDARD",
+  "firstName" : "",
+  "middleName" : "",
+  "lastName" : "",
+  "displayName" : "",
+  "emailAddress" : ""
+}


### PR DESCRIPTION
1. 1. This update fixes an issue when calling the remote dashboard Update API, if a user has a dashboard with the Quality widget configured and only passes and update for sonar, it will clear our the other 3 widgets (Tests, Open Source, Security Scan). 
2.  Adds Fongo testing to get a more fine grain test for the remoteUpdate/Create API.

