### PR TITLE
CodeQuality Collector name can be set using create request

### DIFF
--- a/api/src/main/java/com/capitalone/dashboard/service/CodeQualityServiceImpl.java
+++ b/api/src/main/java/com/capitalone/dashboard/service/CodeQualityServiceImpl.java
@@ -132,7 +132,7 @@ public class CodeQualityServiceImpl implements CodeQualityService {
           Step 2: create Collector item if not there
           Step 3: Insert Quality data if new. If existing, update it.
          */
-        Collector collector = createCollector();
+        Collector collector = createCollector(request);
 
         if (collector == null) {
             throw new HygieiaException("Failed creating code quality collector.", HygieiaException.COLLECTOR_CREATE_ERROR);
@@ -167,9 +167,13 @@ public class CodeQualityServiceImpl implements CodeQualityService {
 
     }
 
-    private Collector createCollector() {
+    private Collector createCollector(CodeQualityCreateRequest request) {
         CollectorRequest collectorReq = new CollectorRequest();
-        collectorReq.setName("Sonar");  //for now hardcode it.
+        if (request.getToolName() != null && !request.getToolName().trim().isEmpty()) {
+            collectorReq.setName(request.getToolName());
+        } else {
+            collectorReq.setName("Sonar");  // keep the default name to Sonar when not specified.
+        }
         collectorReq.setCollectorType(CollectorType.CodeQuality);
         Collector col = collectorReq.toCollector();
         col.setEnabled(true);

--- a/api/src/main/java/com/capitalone/dashboard/service/CodeQualityServiceImpl.java
+++ b/api/src/main/java/com/capitalone/dashboard/service/CodeQualityServiceImpl.java
@@ -169,11 +169,7 @@ public class CodeQualityServiceImpl implements CodeQualityService {
 
     private Collector createCollector(CodeQualityCreateRequest request) {
         CollectorRequest collectorReq = new CollectorRequest();
-        if (request.getToolName() != null && !request.getToolName().trim().isEmpty()) {
-            collectorReq.setName(request.getToolName());
-        } else {
-            collectorReq.setName("Sonar");  // keep the default name to Sonar when not specified.
-        }
+        collectorReq.setName(StringUtils.isEmpty(request.getToolName()) ? "Sonar" : request.getToolName());
         collectorReq.setCollectorType(CollectorType.CodeQuality);
         Collector col = collectorReq.toCollector();
         col.setEnabled(true);


### PR DESCRIPTION
Resolves #2577
with help of pull request to [hygieia-core PR-#36](https://github.com/Hygieia/hygieia-core/pull/36)

* When creating code quality collector the name is set to the specified in the `CodeQualityCreateRequest#toolName`.
* If it is not specified, then the default tool name `Sonar` will be kept (to tally with existing collectors)