### PR TITLE
Fix for docker api container DB hosted outside docker environment.

### DIFF
--- a/api/config.env
+++ b/api/config.env
@@ -4,4 +4,5 @@ SPRING_DATA_MONGODB_HOST=<Data Base Hostname>
 SPRING_DATA_MONGODB_PORT=<Data Base Portname>
 SPRING_DATA_MONGODB_PASSWORD=<DataBase Password>
 SPRING_DATA_MONGODB_USERNAME=<Database username>
+#See https://hygieia.github.io/Hygieia/setup.html#encryption-for-private-repos	
 KEY=<>

--- a/api/config.env
+++ b/api/config.env
@@ -1,0 +1,7 @@
+#Use following argument to update your DB information outside your docker host
+SPRING_DATA_MONGODB_DATABASE=<Data Base Name>
+SPRING_DATA_MONGODB_HOST=<Data Base Hostname>
+SPRING_DATA_MONGODB_PORT=<Data Base Portname>
+SPRING_DATA_MONGODB_PASSWORD=<DataBase Password>
+SPRING_DATA_MONGODB_USERNAME=<Database username>
+KEY=<>

--- a/api/docker/properties-builder.sh
+++ b/api/docker/properties-builder.sh
@@ -38,7 +38,7 @@ dbpassword=${SPRING_DATA_MONGODB_PASSWORD:-dbpassword}
 dbhostport=${SPRING_DATA_MONGODB_HOST}:${SPRING_DATA_MONGODB_PORT}
 
 
-#API encryption key. Optional. See http://capitalone.github.io/Hygieia/setup.html#encryption-for-private-repos	
+#API encryption key. Optional. See https://hygieia.github.io/Hygieia/setup.html#encryption-for-private-repos	
 key=${KEY:-}
 
 logRequest=${LOG_REQUEST:-false}

--- a/api/docker/properties-builder.sh
+++ b/api/docker/properties-builder.sh
@@ -33,7 +33,7 @@ dbusername=${SPRING_DATA_MONGODB_USERNAME:-dashboarduser}
 #Database Password - default is blank
 dbpassword=${SPRING_DATA_MONGODB_PASSWORD:-dbpassword}
 
-#dbhostport 
+
 #This is ensure if you are keeping DB outside docker compose.
 dbhostport=${SPRING_DATA_MONGODB_HOST}:${SPRING_DATA_MONGODB_PORT}
 

--- a/api/docker/properties-builder.sh
+++ b/api/docker/properties-builder.sh
@@ -33,6 +33,11 @@ dbusername=${SPRING_DATA_MONGODB_USERNAME:-dashboarduser}
 #Database Password - default is blank
 dbpassword=${SPRING_DATA_MONGODB_PASSWORD:-dbpassword}
 
+#dbhostport 
+#This is ensure if you are keeping DB outside docker compose.
+dbhostport=${SPRING_DATA_MONGODB_HOST}:${SPRING_DATA_MONGODB_PORT}
+
+
 #API encryption key. Optional. See http://capitalone.github.io/Hygieia/setup.html#encryption-for-private-repos	
 key=${KEY:-}
 


### PR DESCRIPTION
Following issues have been fixed for API docker containers:
1. Added dbhost property to enable DB hosted outside docker.
2. Fixed documentation link for GitHub private repo.
3.Added example docker environment file.
4. Added documentation on Hygieia wiki on how to run API Docker container with environment file.