### PR TITLE
Create Coverity Collector

### DIFF
--- a/UI/src/components/widgets/codeanalysis/view.js
+++ b/UI/src/components/widgets/codeanalysis/view.js
@@ -208,6 +208,15 @@
                     status: data.metrics[index].status
                 });
             }
+
+            // sort issues by severity
+            // undefined sort behavior for severity name not in this list   
+            var sevs = ['Critical', 'High', 'Medium', 'Low'];
+
+            issues.sort(function(a,b) {
+            	return sevs.indexOf(a.name) - sevs.indexOf(b.name);
+            });
+            
             return issues;
         }
 
@@ -354,7 +363,7 @@
                 }
             });
         }
-
+        
         /**
          * Changes timeout boolean to know whether or not to count down
          */
@@ -366,6 +375,10 @@
             }, 7000);
         }
 
+        ctrl.showStatusIcon = function(level) {
+            return true;
+        }
+        
         /**
          * Stops the current cycle promise
          */

--- a/collectors/security/coverity/README.md
+++ b/collectors/security/coverity/README.md
@@ -1,0 +1,44 @@
+# Hygieia Security Collectors / Coverity
+
+Coverity finds software issues of several kinds; however, coverity-collector is only intended to gather _security issues_.
+
+This project uses Spring Boot to package the collector as an executable JAR with dependencies.
+
+## Building and Deploying
+
+Run the following command to package the collector into an executable jar. Find the jar file at `target/`.
+```
+mvn clean install package
+```
+
+Copy this file to your server and launch it using:
+```
+java -jar coverity-collector.jar --spring.config.location=[path to application.properties file]
+```
+
+## application.properties
+
+You will need to provide an **application.properties** file that contains information about how to connect to the Dashboard MongoDB database instance, as well as properties the Coverity collector requires. See the Spring Boot [documentation](http://docs.spring.io/spring-boot/docs/current-SNAPSHOT/reference/htmlsingle/#boot-features-external-config-application-property-files) for information about sourcing this properties file.
+
+### Sample application.properties file
+
+```properties
+# Database Name
+dbname=dashboard
+
+# Database HostName - default is localhost
+dbhost=10.0.1.1
+
+# Database Port - default is 27017
+dbport=27017
+
+# Database Username - default is blank
+dbusername=db
+
+# Database Password - default is blank
+dbpassword=dbpass
+
+
+# Collector schedule (required)
+coverity.cron=0 0/5 * * * *
+```

--- a/collectors/security/coverity/README.md
+++ b/collectors/security/coverity/README.md
@@ -6,6 +6,8 @@ This project uses Spring Boot to package the collector as an executable JAR with
 
 ## Building and Deploying
 
+This collector makes SOAP calls; so wsdl files are required. Update the pom.xml at jaxws-maven-plugin configuration with the wsdl Urls, which is the Coverity Connect server address followed by the paths already given in the pom.xml.
+
 Run the following command to package the collector into an executable jar. Find the jar file at `target/`.
 ```
 mvn clean install package

--- a/collectors/security/coverity/pom.xml
+++ b/collectors/security/coverity/pom.xml
@@ -1,0 +1,164 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<artifactId>coverity-collector</artifactId>
+	<packaging>jar</packaging>
+
+	<name>${project.groupId}:${project.artifactId}</name>
+	<description>Coverity collector for security issues</description>
+
+	<parent>
+		<groupId>com.capitalone.dashboard</groupId>
+		<artifactId>Hygieia</artifactId>
+		<version>3.0.1</version>
+		<relativePath>../../..</relativePath>
+	</parent>
+
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+		<java.version>1.8</java.version>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.apache.ws.security</groupId>
+			<artifactId>wss4j</artifactId>
+			<version>1.6.19</version>
+			<exclusions>
+				<exclusion>
+					<groupId>org.opensaml</groupId>
+					<artifactId>opensaml</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.opensaml</groupId>
+					<artifactId>xmltooling</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.httpcomponents</groupId>
+			<artifactId>httpclient</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-web</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.capitalone.dashboard</groupId>
+			<artifactId>core</artifactId>
+			<version>[3.1.0-SNAPSHOT,)</version>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>commons-io</groupId>
+			<artifactId>commons-io</artifactId>
+			<version>2.4</version>
+		</dependency>
+
+		<dependency>
+			<groupId>commons-collections</groupId>
+			<artifactId>commons-collections</artifactId>
+			<version>3.2.2</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-maven-plugin</artifactId>
+			</plugin>
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>jaxws-maven-plugin</artifactId>
+				<version>2.5</version>
+				<executions>
+					<execution>
+						<id>Configuration Service</id>
+						<goals>
+							<goal>wsimport</goal>
+						</goals>
+						<configuration>
+							<wsdlUrls>
+								<wsdlUrl>http://scappt0008.qcorpaa.aa.com:8080/ws/v9/configurationservice?wsdl</wsdlUrl>
+							</wsdlUrls>
+							<packageName>coverity.ws.configuration</packageName>
+						</configuration>
+					</execution>
+					<execution>
+						<id>Defect Service</id>
+						<goals>
+							<goal>wsimport</goal>
+						</goals>
+						<configuration>
+							<wsdlUrls>
+								<wsdlUrl>http://scappt0008.qcorpaa.aa.com:8080/ws/v9/defectservice?wsdl</wsdlUrl>
+							</wsdlUrls>
+							<packageName>coverity.ws.defect</packageName>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-pmd-plugin</artifactId>
+				<version>${pmd.version}</version>
+				<configuration>
+					<excludeRoots>
+						<excludeRoot>${project.basedir}/target/generated-sources/wsimport/</excludeRoot>
+					</excludeRoots>
+					<rulesets>
+						<ruleset>${project.parent.basedir}/pmd.xml</ruleset>
+					</rulesets>
+				</configuration>
+				<executions>
+					<execution>
+						<phase>validate</phase>
+						<goals>
+							<goal>check</goal>
+							<!-- copy-paste detector disabled for now: -->
+							<!--<goal>cpd-check</goal> -->
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.jacoco</groupId>
+				<artifactId>jacoco-maven-plugin</artifactId>
+				<executions>
+					<execution>
+						<goals>
+							<goal>prepare-agent</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>report</id>
+						<phase>verify</phase>
+						<goals>
+							<goal>report</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<excludes>
+						<exclude>coverity/ws/**/*</exclude>
+					</excludes>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/collectors/security/coverity/pom.xml
+++ b/collectors/security/coverity/pom.xml
@@ -93,7 +93,8 @@
 						</goals>
 						<configuration>
 							<wsdlUrls>
-								<wsdlUrl>http://scappt0008.qcorpaa.aa.com:8080/ws/v9/configurationservice?wsdl</wsdlUrl>
+								<!-- insert cov connect addr before path -->
+								<wsdlUrl>/ws/v9/configurationservice?wsdl</wsdlUrl>
 							</wsdlUrls>
 							<packageName>coverity.ws.configuration</packageName>
 						</configuration>
@@ -105,7 +106,8 @@
 						</goals>
 						<configuration>
 							<wsdlUrls>
-								<wsdlUrl>http://scappt0008.qcorpaa.aa.com:8080/ws/v9/defectservice?wsdl</wsdlUrl>
+								<!-- insert cov connect addr before path -->
+								<wsdlUrl>/ws/v9/defectservice?wsdl</wsdlUrl>
 							</wsdlUrls>
 							<packageName>coverity.ws.defect</packageName>
 						</configuration>

--- a/collectors/security/coverity/src/main/java/com/capitalone/dashboard/Application.java
+++ b/collectors/security/coverity/src/main/java/com/capitalone/dashboard/Application.java
@@ -1,0 +1,12 @@
+package com.capitalone.dashboard;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class Application {
+
+	public static void main(String[] args) {
+		SpringApplication.run(Application.class, args);
+	}
+}

--- a/collectors/security/coverity/src/main/java/com/capitalone/dashboard/collector/CoverityCollectorTask.java
+++ b/collectors/security/coverity/src/main/java/com/capitalone/dashboard/collector/CoverityCollectorTask.java
@@ -1,0 +1,533 @@
+package com.capitalone.dashboard.collector;
+
+import static java.util.Collections.singleton;
+import static java.util.stream.Collectors.groupingBy;
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toSet;
+
+import java.net.MalformedURLException;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.bson.types.ObjectId;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.stereotype.Component;
+
+import com.capitalone.dashboard.collector.coverity.soap.CoveritySoapClient;
+import com.capitalone.dashboard.model.CodeQuality;
+import com.capitalone.dashboard.model.CodeQualityMetric;
+import com.capitalone.dashboard.model.CodeQualityMetricStatus;
+import com.capitalone.dashboard.model.CodeQualityType;
+import com.capitalone.dashboard.model.CollectionError;
+import com.capitalone.dashboard.model.CollectorItem;
+import com.capitalone.dashboard.model.CollectorType;
+import com.capitalone.dashboard.model.Configuration;
+import com.capitalone.dashboard.model.CoverityCollector;
+import com.capitalone.dashboard.model.CoverityProject;
+import com.capitalone.dashboard.model.CoverityScan;
+import com.capitalone.dashboard.repository.BaseCollectorRepository;
+import com.capitalone.dashboard.repository.CodeQualityRepository;
+import com.capitalone.dashboard.repository.ComponentRepository;
+import com.capitalone.dashboard.repository.ConfigurationRepository;
+import com.capitalone.dashboard.repository.CoverityCollectorRepository;
+import com.capitalone.dashboard.repository.CoverityProjectRepository;
+import com.capitalone.dashboard.repository.CoverityScanRepository;
+
+import coverity.ws.configuration.CovRemoteServiceException_Exception;
+import coverity.ws.configuration.ProjectDataObj;
+import coverity.ws.configuration.StreamDataObj;
+import coverity.ws.defect.DefectStateAttributeValueDataObj;
+import coverity.ws.defect.MergedDefectDataObj;
+import coverity.ws.defect.MergedDefectsPageDataObj;
+
+@Component
+public class CoverityCollectorTask extends CollectorTask<CoverityCollector> {
+
+    private static final Log LOG = LogFactory.getLog(CoverityCollectorTask.class);
+
+    private final CoverityCollectorRepository covCollectorRepo;
+    private final CoverityProjectRepository covProjectRepo;
+    private final CoverityScanRepository covScanRepo;
+    private final CodeQualityRepository codeQualityRepo;
+    private final ComponentRepository componentRepo;
+    private final ConfigurationRepository configurationRepo;
+    private final CoveritySoapClient coverityClient;
+    private final CoveritySettings covSettings;
+
+    private static final String LOW_SEV = "Low";
+    private static final String MED_SEV = "Medium";
+    private static final String HIGH_SEV= "High";
+    private static final String CRIT_SEV= "Critical";
+    
+    @Autowired
+    public CoverityCollectorTask(TaskScheduler taskScheduler,
+            CoverityCollectorRepository covCollectorRepo, CoverityProjectRepository covProjectRepo,
+            CoverityScanRepository covScanRepo, CodeQualityRepository codeQualityRepo,
+            ComponentRepository componentRepo, ConfigurationRepository configurationRepo,
+            CoveritySoapClient coverityClient, CoveritySettings covSettings) {
+
+        super(taskScheduler, CoverityCollector.NICE_NAME);
+
+        this.covCollectorRepo = covCollectorRepo;
+        this.covProjectRepo = covProjectRepo;
+        this.covScanRepo = covScanRepo;
+        this.codeQualityRepo = codeQualityRepo;
+        this.componentRepo = componentRepo;
+        this.configurationRepo = configurationRepo;
+        this.coverityClient = coverityClient;
+        this.covSettings = covSettings;
+    }
+
+    @Override
+    public CoverityCollector getCollector() {
+
+        List<String> serverUrls = new ArrayList<>();
+
+        Configuration config = configurationRepo.findByCollectorName(CoverityCollector.NICE_NAME);
+
+        if (config != null) {
+        	for (Map<String, String> coverityServer : config.getInfo()) {
+                serverUrls.add(coverityServer.get("url"));
+            }	
+        }
+    
+        return CoverityCollector.prototype(serverUrls);
+    }
+
+    @Override
+    public BaseCollectorRepository<CoverityCollector> getCollectorRepository() {
+        return covCollectorRepo;
+    }
+
+    @Override
+    public String getCron() {
+        return covSettings.getCron();
+    }
+
+    @Override
+    public void collect(CoverityCollector collector) {
+
+        long start = System.currentTimeMillis();
+
+        Configuration config = configurationRepo.findByCollectorName(CoverityCollector.NICE_NAME);
+        
+        if (config == null) {
+        	LOG.info("No Coverity Servers Configured");
+            return;
+        }
+        
+        config.decryptOrEncrptInfo();
+        coverityClient.setServerDetails(config.getInfo());
+
+        // Retrieve projects previously persisted to the database
+        List<CoverityProject> persistedProjs =
+                covProjectRepo.findByCollectorIdIn(singleton(collector.getId()));
+
+        // aggregate projects collected from all Coverity Servers
+        // used to handleDeadProjects
+        List<CoverityProject> allCoverityProjs = new LinkedList<>();
+
+        for (String instanceUrl : collector.getCoverityServers()) {
+
+            logBanner(instanceUrl);
+
+            List<CoverityProject> persistedInstanceProjs = persistedProjs.stream()
+                    .filter(p -> p.getInstanceUrl().equals(instanceUrl)).collect(toList());
+
+            refreshEnabledWidgetStateforProjects(collector, persistedInstanceProjs);
+
+            try {
+                List<CoverityProject> covProjs = coverityClient.getAllProjects(instanceUrl).stream() // throws
+                        .map(this::fromProjectDataObj) // convert each to List<CoverityProject> type
+                        .flatMap(List::stream)
+                        .collect(toList());
+
+                for (CoverityProject p : covProjs) {
+                    p.setCollectorId(collector.getId());
+                    p.setInstanceUrl(instanceUrl);
+                }
+
+                allCoverityProjs.addAll(covProjs);
+
+                log("Fetched projects: " + covProjs.size(), start);
+
+                refreshProjects(start, persistedInstanceProjs, covProjs);
+
+                // collect defect data for enabled projects
+                // enabled means there is a widget on a dashboard configured to view the project
+                List<CoverityProject> enabledProjs =
+                        covProjectRepo.findEnabledProjects(collector.getId(), instanceUrl);
+
+                log("collecting defects for projects: "+enabledProjs.size());
+
+                List<CoverityScan> scans = new ArrayList<>();
+                List<CodeQuality> qualities = new ArrayList<>();
+
+                addDetailsFromProjs(enabledProjs, scans, qualities, instanceUrl, start);
+
+                covScanRepo.save(scans);
+                codeQualityRepo.save(qualities);
+
+            } catch (CovRemoteServiceException_Exception e) {
+                LOG.error("Project SOAP request error:  "+instanceUrl, e);
+            } catch (MalformedURLException e) {
+                LOG.error("Malformed Url (may be missing protocol):" + instanceUrl, e);
+            }
+        }
+
+        handleDeadProjects(persistedProjs, allCoverityProjs, collector);
+    }
+
+    private void addDetailsFromProjs(List<CoverityProject> ps, List<CoverityScan> ss, List<CodeQuality> qs,
+            String instanceUrl, long start) {
+
+        for (CoverityProject proj : ps) {
+            try {
+                String streamName = proj.getStream();
+
+                List<MergedDefectDataObj> mergedDefects = collectDefectsForStream(instanceUrl, streamName); // throws
+
+                CoverityScan scan = makeCovScanObj(proj, streamName, mergedDefects, start);
+                CodeQuality  quality = makeCodeQualityObj(proj, scan);
+
+                if (isNewCoverityScanData(proj, scan) && isNewCodeQualityData(proj, quality)) {
+                    log("Collecting new defect data for "+proj.getDescription());
+                    ss.add(scan);
+                    qs.add(quality);
+                } else {
+                    log("No new data for project "+proj.getDescription());
+                }
+            } catch (coverity.ws.defect.CovRemoteServiceException_Exception e) {
+                LOG.error("Defect SOAP request error: "+instanceUrl, e);
+            } catch (Exception e) {
+                LOG.error(e);
+            }
+        }
+    }
+
+    private boolean isNewCoverityScanData(CoverityProject proj, CoverityScan covScan) {
+        return covScanRepo.findByCollectorItemIdAndTimestamp(proj.getId(), covScan.getTimestamp()) == null;
+    }
+
+    private boolean isNewCodeQualityData(CoverityProject proj, CodeQuality codeQ) {
+
+        int defectsFound = codeQ.getMetrics().stream()
+            .map(CodeQualityMetric::getFormattedValue)
+            .mapToInt(Integer::parseInt).sum();
+
+        // if no defects were found in latest fetched scan
+        // check the latest saved scan to see if fetched scan is different
+        if (defectsFound == 0) {
+
+            List<CodeQuality> persistedCodeQs = codeQualityRepo.findByCollectorItemIdOrderByTimestampDesc(proj.getId());
+            if (persistedCodeQs.isEmpty()) {
+                return true; // new scan
+            }
+
+            int defectsInLastScan = persistedCodeQs.get(0).getMetrics().stream()
+                .map(CodeQualityMetric::getFormattedValue)
+                .mapToInt(Integer::parseInt).sum();
+
+            return defectsInLastScan != defectsFound; // if different then this is a new scan
+        }
+
+        return codeQualityRepo.findByCollectorItemIdAndTimestamp(proj.getId(), codeQ.getTimestamp()) == null;
+    }
+
+    // Build a CodeQuality object for the given scan (serves as a summary of the scan)
+    private CodeQuality makeCodeQualityObj(CoverityProject proj, CoverityScan cs) {
+
+        Set<CodeQualityMetric> metrics = new HashSet<>();
+
+        for (String severity : getSeverities()) {
+            CodeQualityMetric metric = new CodeQualityMetric(severity);
+
+            metric.setFormattedValue(
+                    Integer.toString(cs.getDefectsBySeverity().get(severity).size()));
+
+            if (severity.equals(HIGH_SEV) || severity.equals(CRIT_SEV)) {
+                metric.setStatus(CodeQualityMetricStatus.Alert);
+            } else {
+                metric.setStatus(CodeQualityMetricStatus.Warning);
+            }
+
+            metrics.add(metric);
+        }
+
+        CodeQuality cq = new CodeQuality();
+        cq.setCollectorItemId(proj.getId());
+        cq.setTimestamp(cs.getTimestamp());
+        cq.setName(proj.getDescription());
+        cq.setUrl(proj.getInstanceUrl());
+        cq.setType(CodeQualityType.SecurityAnalysis);
+
+        cq.getMetrics().addAll(metrics);
+
+        return cq;
+    }
+
+    // this method helps guarantee that the severities will be fetched in a fresh state
+    private String[] getSeverities() {
+        return new String[] {LOW_SEV, MED_SEV, HIGH_SEV, CRIT_SEV};
+    }
+
+    // Build a CoverityScan object from the given defects.
+    private CoverityScan makeCovScanObj(CoverityProject proj, String stream,
+            List<MergedDefectDataObj> mergedDefects, long start) {
+
+        Stream<CoverityScan.Defect> defects = mergedDefects.stream()
+                .map(this::fromMergedDefect);
+
+        Map<String, List<CoverityScan.Defect>> defectsBySeverity = defects
+                .collect(groupingBy(CoverityScan.Defect::getCvssSeverity));
+
+        CoverityScan cs = new CoverityScan();
+        cs.setName(proj.getDescription());
+        cs.setProjectKey(proj.getProjectKey());
+        cs.setStream(stream);
+        cs.setCovConnectUrl(proj.getInstanceUrl());
+        cs.setCollectorItemId(proj.getId());
+
+        cs.getDefectsBySeverity().put(LOW_SEV, emptyIfNull(defectsBySeverity.get(LOW_SEV)));
+        cs.getDefectsBySeverity().put(MED_SEV, emptyIfNull(defectsBySeverity.get(MED_SEV)));
+        cs.getDefectsBySeverity().put(HIGH_SEV, emptyIfNull(defectsBySeverity.get(HIGH_SEV)));
+        cs.getDefectsBySeverity().put(CRIT_SEV, emptyIfNull(defectsBySeverity.get(CRIT_SEV)));
+
+        if (mergedDefects.isEmpty()) {
+            cs.setTimestamp(start);
+        } else {
+            cs.setTimestamp(mergedDefects.get(0).getLastDetected().toGregorianCalendar().getTimeInMillis());
+        }
+
+        return cs;
+    }
+
+    private <T> List<T> emptyIfNull(List<T> nullableList) {
+        return nullableList == null
+                ? new ArrayList<>()
+                : nullableList;
+    }
+
+    /**
+     * Query the given Coverity Connect Server URL for latest snapshot defects in given stream.
+     * @param instanceUrl Coverity Connect Server
+     * @param stream Project Stream name
+     * @return List of defects (generated WSDL type)
+     * @throws coverity.ws.defect.CovRemoteServiceException_Exception
+     * @throws MalformedURLException
+     */
+    private List<MergedDefectDataObj> collectDefectsForStream(String instanceUrl, String stream)
+            throws coverity.ws.defect.CovRemoteServiceException_Exception, MalformedURLException {
+
+        // gather all defects
+        List<MergedDefectDataObj> defects = new ArrayList<>();
+
+        MergedDefectsPageDataObj defectsPage;
+        int pageIx = 0;
+
+        defectsPage = coverityClient.getSecurityDefectsForStream(instanceUrl, stream, pageIx);
+        defects.addAll(defectsPage.getMergedDefects());
+
+        int lastPageIx = defectsPage.getTotalNumberOfRecords() / 1000; // 1000 records per page
+
+        for (pageIx = 1; pageIx <= lastPageIx; pageIx++) {
+            defectsPage = coverityClient.getSecurityDefectsForStream(instanceUrl, stream, pageIx);
+            defects.addAll(defectsPage.getMergedDefects());
+        }
+
+        return defects;
+    }
+
+    /**
+     * Save new projects and update previously persisted projects.
+     * @param start
+     * @param persistedInstanceProjs
+     * @param covConnectProjs
+     */
+    private void refreshProjects(long start, List<CoverityProject> persistedInstanceProjs,
+            List<CoverityProject> covConnectProjs) {
+
+        List<CoverityProject> newProjs = new ArrayList<>();
+        List<CoverityProject> staleExistingProjs = new ArrayList<>();
+
+        for (CoverityProject covProj : covConnectProjs) {
+            int ix = persistedInstanceProjs.indexOf(covProj);
+
+            if (ix == -1) {
+                // new project
+                newProjs.add(covProj);
+            } else if (covProj.getDateModified() > persistedInstanceProjs.get(ix).getDateModified()) {
+                // existing project is stale
+
+                // set ObjectId for update on save
+                covProj.setId(persistedInstanceProjs.get(ix).getId());
+                staleExistingProjs.add(covProj);
+            }
+        }
+
+        // add new projects
+        ArrayList<CoverityProject> saved =
+                (ArrayList<CoverityProject>) covProjectRepo.save(newProjs);
+
+        // save returns null when testing because repo is mocked
+        if (saved != null)
+            log("New projects saved: " + saved.size(), start);
+
+        // update existing projects
+        saved = (ArrayList<CoverityProject>) covProjectRepo.save(staleExistingProjs);
+
+        if (saved != null)
+            log("Projects refreshed: " + saved.size(), start);
+    }
+
+    /**
+     * Dead Projects are projects in database but no longer exists in coverity.
+     * Other collectors call this method deleteUnwantedJobs.
+     * @param persistedProjs
+     * @param allFetchedCovProjs
+     * @param collector
+     */
+    private void handleDeadProjects(List<CoverityProject> persistedProjs, List<CoverityProject> allFetchedCovProjs,
+            CoverityCollector collector) {
+
+        List<CoverityProject> deadProjs = persistedProjs.stream()
+                .filter(p -> ! p.isPushed()) // maybe only related to jenkins collector (keep for consistency)
+                .filter(p -> ! collector.getId().equals(p.getCollectorId())
+                        ||   ! collector.getCoverityServers().contains(p.getInstanceUrl())
+                        ||   ! allFetchedCovProjs.contains(p))
+                .collect(toList());
+
+        List<CoverityProject> zombies = new ArrayList<>();
+        List<CoverityProject> garbage = new ArrayList<>();
+
+        for (CoverityProject deadProj : deadProjs) {
+            if (deadProj.isEnabled()) {
+
+                LOG.info("setting error for "+deadProj.getDescription());
+
+                // error can be used to inform user
+                // widget is configured to zombie project
+                CollectionError error = new CollectionError(
+                		HttpStatus.NOT_FOUND.toString(),
+                        "Coverity project not found");
+
+                deadProj.getErrors().clear();
+                deadProj.getErrors().add(error);
+
+                zombies.add(deadProj);
+            } else {
+                List<CoverityScan> covScans = covScanRepo.findByCollectorItemId(deadProj.getId());
+                covScanRepo.delete(covScans);
+
+                List<CodeQuality> cqs = codeQualityRepo.findByCollectorItemIdOrderByTimestampDesc(deadProj.getId());
+                codeQualityRepo.delete(cqs);
+
+                garbage.add(deadProj);
+            }
+        }
+
+        covProjectRepo.save(zombies);
+        covProjectRepo.delete(garbage);
+    }
+
+    /**
+     * Called clean in other collectors. Update whether a widget is using this project.
+     * @param collector
+     * @param persistedInstanceProjs
+     */
+    private void refreshEnabledWidgetStateforProjects(CoverityCollector collector,
+            List<CoverityProject> persistedInstanceProjs) {
+
+        // extract unique collector item IDs from components
+        // (in this context collector_items are coverity projects)
+        Set<ObjectId> uniqueIDs = StreamSupport.stream(componentRepo.findAll().spliterator(), false)
+                .filter(comp -> comp.getCollectorItems() != null)
+                .filter(comp -> ! comp.getCollectorItems().isEmpty())
+                .map(comp -> comp.getCollectorItems(CollectorType.StaticSecurityScan))
+                // keep nonNull List<CollectorItem>
+                .filter(Objects::nonNull)
+                // merge all lists (flatten) into a stream
+                .flatMap(List::stream)
+                // keep nonNull CollectorItems
+                .filter(Objects::nonNull)
+                .filter(collectorItem -> collectorItem.getCollectorId().equals(collector.getId()))
+                .map(CollectorItem::getId).collect(toSet());
+
+        List<CoverityProject> stateChangeProjectList = new ArrayList<>();
+
+        for (CoverityProject proj : persistedInstanceProjs) {
+            if ((proj.isEnabled() && !uniqueIDs.contains(proj.getId()))
+                    || (!proj.isEnabled() && uniqueIDs.contains(proj.getId()))) {
+
+                proj.setEnabled(uniqueIDs.contains(proj.getId()));
+                stateChangeProjectList.add(proj);
+            }
+        }
+
+        if (!stateChangeProjectList.isEmpty()) {
+            covProjectRepo.save(stateChangeProjectList);
+        }
+    }
+
+    /**
+     * Utility method to convert from ProjDataObj to CoverityProjects
+     * Each stream in the ProjDataObj will be its own CoverityProject
+     * @param soapProjObj received from Soap API
+     * @return application model CoverityProjects
+     */
+    private List<CoverityProject> fromProjectDataObj(ProjectDataObj soapProjObj) {
+
+        List<CoverityProject> covApps = new ArrayList<>();
+
+        for (StreamDataObj stream : soapProjObj.getStreams()) {
+
+            CoverityProject covApp = new CoverityProject();
+
+            // description is used in the api layer to lookup projects
+            covApp.setDescription(soapProjObj.getId().getName(), stream.getId().getName());
+            covApp.setProjectKey(soapProjObj.getProjectKey());
+            covApp.setDateCreated(soapProjObj.getDateCreated().toGregorianCalendar().getTimeInMillis() / 1000);
+            covApp.setDateModified(soapProjObj.getDateModified().toGregorianCalendar().getTimeInMillis() / 1000);
+
+            covApps.add(covApp);
+        }
+
+        return covApps;
+    }
+
+    /**
+     * Utility method to convert from MergedDefectDataObj to CoverityScan.Defect
+     * @param d SOAP defect
+     * @return application model CoverityScan.Defect
+     */
+    private CoverityScan.Defect fromMergedDefect(MergedDefectDataObj d) {
+
+        String cvssSeverity = "None";
+        String cvssScore = "0";
+
+        // coverity admin has added these attributes to all "projects"
+        for (DefectStateAttributeValueDataObj attr : d.getDefectStateAttributeValues()) {
+            if ("CVSS_Severity".equals(attr.getAttributeDefinitionId().getName())) {
+                cvssSeverity = attr.getAttributeValueId().getName();
+            }
+            if ("CVSS_Score".equals(attr.getAttributeDefinitionId().getName())) {
+                cvssScore = attr.getAttributeValueId().getName();
+            }
+        }
+
+        return new CoverityScan.Defect(
+                d.getCid(), d.getDisplayType(), d.getFilePathname(),
+                cvssSeverity, cvssScore);
+    }
+}

--- a/collectors/security/coverity/src/main/java/com/capitalone/dashboard/collector/CoveritySettings.java
+++ b/collectors/security/coverity/src/main/java/com/capitalone/dashboard/collector/CoveritySettings.java
@@ -1,0 +1,20 @@
+package com.capitalone.dashboard.collector;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConfigurationProperties(prefix = "coverity")
+public class CoveritySettings {
+
+	private String cron;
+	
+	public String getCron() {
+		return cron;
+	}
+	
+	public void setCron(String cron) {
+		this.cron = cron;
+	}
+    
+}

--- a/collectors/security/coverity/src/main/java/com/capitalone/dashboard/collector/coverity/soap/ClientAuthHeaderHandlerWSS.java
+++ b/collectors/security/coverity/src/main/java/com/capitalone/dashboard/collector/coverity/soap/ClientAuthHeaderHandlerWSS.java
@@ -1,0 +1,72 @@
+package com.capitalone.dashboard.collector.coverity.soap;
+
+import java.util.Set;
+
+import javax.xml.namespace.QName;
+import javax.xml.soap.SOAPMessage;
+import javax.xml.soap.SOAPPart;
+import javax.xml.ws.handler.MessageContext;
+import javax.xml.ws.handler.soap.SOAPHandler;
+import javax.xml.ws.handler.soap.SOAPMessageContext;
+
+import org.apache.ws.security.WSConstants;
+import org.apache.ws.security.message.WSSecHeader;
+import org.apache.ws.security.message.WSSecUsernameToken;
+
+/**
+ * Coverity uses ws-security for client requests.
+ * This handler will insert username and password to the SOAP header.  
+ */
+public class ClientAuthHeaderHandlerWSS implements SOAPHandler<SOAPMessageContext> {
+
+    private final String usernameText;
+    private final String passwordText;
+
+    public ClientAuthHeaderHandlerWSS(String usernameText, String passwordText) {
+        this.usernameText = usernameText;
+        this.passwordText = passwordText;
+    }
+
+    @Override
+    public boolean handleMessage(SOAPMessageContext context) {
+        Boolean outboundProperty = (Boolean) context.get(MessageContext.MESSAGE_OUTBOUND_PROPERTY);
+
+        if (outboundProperty.booleanValue()) {
+
+            try {
+                SOAPMessage soapMessage = context.getMessage();
+                soapMessage.removeAllAttachments();
+
+                SOAPPart soappart = soapMessage.getSOAPPart();
+                WSSecHeader wsSecHeader = new WSSecHeader();
+                wsSecHeader.insertSecurityHeader(soappart);
+                WSSecUsernameToken token = new WSSecUsernameToken();
+                token.setPasswordType(WSConstants.PASSWORD_TEXT);
+                token.setUserInfo(usernameText, passwordText);
+                token.build(soappart, wsSecHeader);
+
+                soapMessage.saveChanges();
+            } catch (Exception e) {
+                throw new RuntimeException("Error on wsSecurityHandler: " + e.getMessage());
+            }
+
+        }
+
+        return true;
+    }
+
+    @Override
+    public boolean handleFault(SOAPMessageContext context) {
+        return false;
+    }
+
+    @Override
+    public void close(MessageContext context) {
+
+    }
+
+    @Override
+    public Set<QName> getHeaders() {
+        return null;
+    }
+}

--- a/collectors/security/coverity/src/main/java/com/capitalone/dashboard/collector/coverity/soap/CoveritySoapClient.java
+++ b/collectors/security/coverity/src/main/java/com/capitalone/dashboard/collector/coverity/soap/CoveritySoapClient.java
@@ -1,0 +1,190 @@
+package com.capitalone.dashboard.collector.coverity.soap;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import javax.xml.namespace.QName;
+import javax.xml.ws.BindingProvider;
+
+import org.springframework.stereotype.Component;
+
+import coverity.ws.configuration.ConfigurationService;
+import coverity.ws.configuration.ConfigurationServiceService;
+import coverity.ws.configuration.CovRemoteServiceException_Exception;
+import coverity.ws.configuration.ProjectDataObj;
+import coverity.ws.configuration.ProjectFilterSpecDataObj;
+import coverity.ws.defect.DefectService;
+import coverity.ws.defect.DefectServiceService;
+import coverity.ws.defect.MergedDefectFilterSpecDataObj;
+import coverity.ws.defect.MergedDefectsPageDataObj;
+import coverity.ws.defect.PageSpecDataObj;
+import coverity.ws.defect.SnapshotScopeSpecDataObj;
+import coverity.ws.defect.StreamIdDataObj;
+
+/**
+ * CoveritySoapClient is effectively a wrapper around the services defined in the WSDL.
+ * The Coverity Connect server queried should have a compatible WSDL definition/version
+ * to the one used to generate sources with wsimport.
+ */
+@Component
+public class CoveritySoapClient {
+
+    private ConfigurationService configService;
+    private DefectService defectService;
+
+    // Maps contain keys: url, userName, and password
+    private Set<Map<String, String>> coverityServers;
+
+    /**
+     * Get a list of all Coverity projects (each project includes its own streams)
+     * @return List of all projects
+     * @throws CovRemoteServiceException_Exception
+     * @throws MalformedURLException
+     */
+    public List<ProjectDataObj> getAllProjects(String instanceUrl)
+            throws CovRemoteServiceException_Exception, MalformedURLException {
+
+        String usr = getUsername(instanceUrl);
+        String pwd = getPassword(instanceUrl);
+
+        ProjectFilterSpecDataObj filter = new ProjectFilterSpecDataObj();
+        filter.setIncludeChildren(true); // so that dates are included in response
+        filter.setIncludeStreams(true);  // defects collected by stream for each project
+
+        setCSCreds(instanceUrl, usr, pwd);
+
+        return getProjectsStubbable(filter);
+    }
+
+    /**
+     * Wrapper method for configService call. Makes mocking in tests possible. Package-Private intentionally.
+     * @throws MalformedURLException
+     */
+    List<ProjectDataObj> getProjectsStubbable(ProjectFilterSpecDataObj filter)
+            throws CovRemoteServiceException_Exception {
+
+        return configService.getProjects(filter);
+    }
+
+    /**
+     * Get defects for Current Snapshot 1000 at a time. Use pageIx to go through pages.
+     * @param instanceUrl address to the Coverity server (must include protocol; i.e. 'http://')
+     * @param stream Stream in project to be queried
+     * @param pageIx Zero-based index of page to return
+     * @return Paged defects
+     * @throws coverity.ws.defect.CovRemoteServiceException_Exception
+     * @throws MalformedURLException
+     */
+    public MergedDefectsPageDataObj getSecurityDefectsForStream(String instanceUrl, String stream, int pageIx)
+            throws coverity.ws.defect.CovRemoteServiceException_Exception, MalformedURLException {
+
+        String usr = getUsername(instanceUrl);
+        String pwd = getPassword(instanceUrl);
+
+        StreamIdDataObj sid = new StreamIdDataObj();
+        sid.setName(stream);
+
+        List<StreamIdDataObj> streamIds = new ArrayList<>();
+        streamIds.add(sid);
+
+        // filter-object based on the settings of the default view in coverity connect
+        // "Outstanding Security Issues" (except no grouping)
+        MergedDefectFilterSpecDataObj filter = new MergedDefectFilterSpecDataObj();
+        filter.getClassificationNameList().addAll(Arrays.asList("Unclassified", "Pending", "Untested"));
+        // Impact:   select all (no filtering)
+        filter.getIssueKindList().add("SECURITY");
+        // Severity: select all (no filtering)
+        // Type:     select all (no filtering)
+
+        PageSpecDataObj pageSpec = new PageSpecDataObj();
+        pageSpec.setPageSize(1000); // this is the max number of records per page
+        pageSpec.setStartIndex(1000*pageIx);
+
+        SnapshotScopeSpecDataObj snapshotScope = new SnapshotScopeSpecDataObj();
+        // default values explicitly given here
+        snapshotScope.setCompareOutdatedStreams(false);
+        snapshotScope.setShowOutdatedStreams(false);
+        snapshotScope.setShowSelector("last()");
+
+        setDSCreds(instanceUrl, usr, pwd);
+
+        return getMergedDefectsForStreamsStubbable(streamIds, filter, pageSpec, snapshotScope);
+    }
+
+    /**
+     * Wrapper method for defectService call. Makes mocking in tests possible. Package-Private intentionally.
+     * @throws MalformedURLException
+     */
+    MergedDefectsPageDataObj getMergedDefectsForStreamsStubbable(List<StreamIdDataObj> streamIds,
+            MergedDefectFilterSpecDataObj filterSpec, PageSpecDataObj pageSpec, SnapshotScopeSpecDataObj snapshotScope)
+            throws coverity.ws.defect.CovRemoteServiceException_Exception {
+
+        return defectService.getMergedDefectsForStreams(streamIds, filterSpec, pageSpec, snapshotScope);
+    }
+
+    private void setCSCreds(String instanceUrl, String user, String pword) throws MalformedURLException {
+
+        ConfigurationServiceService css = stubbableNewCofigSrvcSrvc(instanceUrl);
+        configService = css.getConfigurationServicePort();
+
+        BindingProvider bp = (BindingProvider) configService;
+        bp.getBinding().setHandlerChain(
+                Arrays.asList(new ClientAuthHeaderHandlerWSS(user, pword)));
+    }
+
+    ConfigurationServiceService stubbableNewCofigSrvcSrvc(String instanceUrl) throws MalformedURLException {
+        return new ConfigurationServiceService(
+                new URL(instanceUrl + "/ws/v9/configurationservice?wsdl"),
+                new QName("http://ws.coverity.com/v9", "ConfigurationServiceService"));
+    }
+
+    private void setDSCreds(String instanceUrl, String user, String pword) throws MalformedURLException {
+
+        DefectServiceService dss = stubbableNewDefectSrvcSrvc(instanceUrl);
+        defectService = dss.getDefectServicePort();
+
+        BindingProvider bp = (BindingProvider) defectService;
+        bp.getBinding().setHandlerChain(
+                Arrays.asList(new ClientAuthHeaderHandlerWSS(user, pword)));
+    }
+
+    DefectServiceService stubbableNewDefectSrvcSrvc(String instanceUrl) throws MalformedURLException {
+        return new DefectServiceService(
+                new URL(instanceUrl + "/ws/v9/defectservice?wsdl"),
+                new QName("http://ws.coverity.com/v9", "DefectServiceService"));
+    }
+
+    /**
+     * Set Coverity Connect server details: url, username, password.
+     * Other collectors unfortunately call this method connectDB.
+     * @param coverityServers
+     */
+    public void setServerDetails(Set<Map<String,String>> coverityServers) {
+        this.coverityServers = coverityServers;
+    }
+
+    private String getUsername(String url) {
+
+        for (Map<String, String> coverityServer : coverityServers) {
+            if (url.contains(coverityServer.get("url"))) {
+                return coverityServer.get("userName");
+            }
+        }
+        return null;
+    }
+
+    private String getPassword(String url) {
+
+        for (Map<String, String> coverityServer : coverityServers) {
+            if (url.contains(coverityServer.get("url"))) {
+                return coverityServer.get("password");
+            }
+        }
+        return null;
+    }
+}

--- a/collectors/security/coverity/src/main/java/com/capitalone/dashboard/model/CoverityCollector.java
+++ b/collectors/security/coverity/src/main/java/com/capitalone/dashboard/model/CoverityCollector.java
@@ -1,0 +1,25 @@
+package com.capitalone.dashboard.model;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class CoverityCollector extends Collector {
+	
+	public static final String NICE_NAME = "Coverity";
+	
+    private List<String> coverityServers = new ArrayList<>();
+
+    public List<String> getCoverityServers() {
+        return coverityServers;
+    }
+
+    public static CoverityCollector prototype(List<String> servers) {
+    	CoverityCollector protoType = new CoverityCollector();
+        protoType.setName(NICE_NAME);
+        protoType.setCollectorType(CollectorType.StaticSecurityScan);
+        protoType.setOnline(true);
+        protoType.setEnabled(true);
+        protoType.getCoverityServers().addAll(servers);
+        return protoType;
+    }
+}

--- a/collectors/security/coverity/src/main/java/com/capitalone/dashboard/model/CoverityProject.java
+++ b/collectors/security/coverity/src/main/java/com/capitalone/dashboard/model/CoverityProject.java
@@ -1,0 +1,105 @@
+package com.capitalone.dashboard.model;
+
+/**
+ * Special use case at AA: Coverity Project is used as a "folder."
+ * Coverity Streams within Coverity Project are used for the actual application.
+ *
+ * Hence a unique "CoverityProject" is identified by
+ * Coverity Project AND Coverity Stream.
+ *
+ * The Class name is misleading.
+ */
+public class CoverityProject extends CollectorItem {
+
+    // keys for inherited Map<String, Object> options
+    private static final String PROJECT_NAME = "projectName";
+    private static final String INSTANCE_URL = "instanceUrl";
+    private static final String PROJECT_KEY = "projectKey";
+    private static final String DATE_CREATED = "dateCreated";
+    private static final String DATE_MODIFIED= "dateModified";
+    private static final String STREAM = "stream";
+
+    /**
+     * Do not use inherited setDescription(String) method from CollectorItem
+     * to avoid inconsistent state
+     * @param projectName
+     * @param stream
+     */
+    public void setDescription(String projectName, String stream) {
+        super.setDescription(projectName+": "+stream);
+
+        setProjectName(projectName);
+        setStream(stream);
+    }
+
+    public String getProjectName() {
+        return (String) getOptions().get(PROJECT_NAME);
+    }
+
+    private void setProjectName(String projectName) {
+        getOptions().put(PROJECT_NAME, projectName);
+    }
+
+	public Long getProjectKey() {
+        return (Long) getOptions().get(PROJECT_KEY);
+    }
+
+    public void setProjectKey(long projectKey) {
+        getOptions().put(PROJECT_KEY, projectKey);
+    }
+
+    public Long getDateCreated() {
+        return (Long) getOptions().get(DATE_CREATED);
+    }
+
+    public void setDateCreated(long dateCreated) {
+        getOptions().put(DATE_CREATED, dateCreated);
+    }
+
+    public Long getDateModified() {
+        return (Long) getOptions().get(DATE_MODIFIED);
+    }
+
+    public void setDateModified(long dateModified) {
+        getOptions().put(DATE_MODIFIED, dateModified);
+    }
+
+    public String getStream() {
+        return (String) getOptions().get(STREAM);
+    }
+
+    private void setStream(String stream) {
+        getOptions().put(STREAM, stream);
+    }
+
+    public String getInstanceUrl() {
+        return (String) getOptions().get(INSTANCE_URL);
+    }
+
+    public void setInstanceUrl(String instanceUrl) {
+        getOptions().put(INSTANCE_URL, instanceUrl);
+    }
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o)
+			return true;
+		if (o == null || getClass() != o.getClass())
+			return false;
+
+		CoverityProject that = (CoverityProject) o;
+		return getProjectKey().equals(that.getProjectKey())
+		        && getDateCreated().equals(that.getDateCreated())
+		        && getInstanceUrl().equals(that.getInstanceUrl());
+	}
+
+	@Override
+	public int hashCode() {
+		int result = getInstanceUrl().hashCode();
+		long dateCreated = getDateCreated();
+
+		result = 31 * result + getDescription().hashCode() + (int) dateCreated;
+		return result;
+	}
+
+}

--- a/collectors/security/coverity/src/main/java/com/capitalone/dashboard/model/CoverityScan.java
+++ b/collectors/security/coverity/src/main/java/com/capitalone/dashboard/model/CoverityScan.java
@@ -1,0 +1,122 @@
+package com.capitalone.dashboard.model;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.bson.types.ObjectId;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+/**
+ * Detailed record of defects in a coverity scan.
+ */
+@Document(collection = "coverity_scan")
+public class CoverityScan extends BaseModel {
+
+    // project identification
+    private String name;
+    private long projectKey;
+    private String stream;
+    private String covConnectUrl;
+
+    // foreign key to CoverityProject
+    private ObjectId collectorItemId;
+
+    private long timestamp;
+
+    // keys are Impact level (Low, Medium, High, Critical)
+    private Map<String, List<Defect>> defectsBySeverity = new HashMap<>();
+
+    public static class Defect {
+        // These fields seem relevant...
+        private long cid;
+        private String type;
+        private String filePath;
+        private String cvssSeverity;
+        private String cvssScore;
+
+        public Defect(long cid, String type, String filePath, String cvssSeverity, String cvssScore) {
+            this.cid = cid;
+            this.type = type;
+            this.filePath = filePath;
+            this.cvssSeverity = cvssSeverity;
+            this.cvssScore = cvssScore;
+        }
+
+        public long getCid() {
+            return cid;
+        }
+
+        public String getType() {
+            return type;
+        }
+
+        public String getFilePath() {
+            return filePath;
+        }
+
+        public String getCvssSeverity() {
+            return cvssSeverity;
+        }
+
+        public String getCvssScore() {
+            return cvssScore;
+        }
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public long getProjectKey() {
+        return projectKey;
+    }
+
+    public void setProjectKey(long projectKey) {
+        this.projectKey = projectKey;
+    }
+
+    public String getStream() {
+        return stream;
+    }
+
+    public void setStream(String stream) {
+        this.stream = stream;
+    }
+
+    public String getCovConnectUrl() {
+        return covConnectUrl;
+    }
+
+    public void setCovConnectUrl(String covConnectUrl) {
+        this.covConnectUrl = covConnectUrl;
+    }
+
+    public ObjectId getCollectorItemId() {
+        return collectorItemId;
+    }
+
+    public void setCollectorItemId(ObjectId collectorItemId) {
+        this.collectorItemId = collectorItemId;
+    }
+
+    public long getTimestamp() {
+        return timestamp;
+    }
+
+    public void setTimestamp(long timestamp) {
+        this.timestamp = timestamp;
+    }
+
+    public Map<String, List<Defect>> getDefectsBySeverity() {
+        return defectsBySeverity;
+    }
+
+    public void setDefectsBySeverity(Map<String, List<Defect>> defectsBySeverity) {
+        this.defectsBySeverity = defectsBySeverity;
+    }
+}

--- a/collectors/security/coverity/src/main/java/com/capitalone/dashboard/repository/CoverityCollectorRepository.java
+++ b/collectors/security/coverity/src/main/java/com/capitalone/dashboard/repository/CoverityCollectorRepository.java
@@ -1,0 +1,7 @@
+package com.capitalone.dashboard.repository;
+
+import com.capitalone.dashboard.model.CoverityCollector;
+
+public interface CoverityCollectorRepository extends BaseCollectorRepository<CoverityCollector> {
+
+}

--- a/collectors/security/coverity/src/main/java/com/capitalone/dashboard/repository/CoverityProjectRepository.java
+++ b/collectors/security/coverity/src/main/java/com/capitalone/dashboard/repository/CoverityProjectRepository.java
@@ -1,0 +1,15 @@
+package com.capitalone.dashboard.repository;
+
+import java.util.List;
+
+import org.bson.types.ObjectId;
+import org.springframework.data.mongodb.repository.Query;
+
+import com.capitalone.dashboard.model.CoverityProject;
+
+public interface CoverityProjectRepository extends BaseCollectorItemRepository<CoverityProject>{
+
+    @Query(value="{ 'collectorId' : ?0, options.instanceUrl : ?1, enabled: true}")
+	List<CoverityProject> findEnabledProjects(ObjectId id, String instanceUrl);
+
+}

--- a/collectors/security/coverity/src/main/java/com/capitalone/dashboard/repository/CoverityScanRepository.java
+++ b/collectors/security/coverity/src/main/java/com/capitalone/dashboard/repository/CoverityScanRepository.java
@@ -1,0 +1,15 @@
+package com.capitalone.dashboard.repository;
+
+import java.util.List;
+
+import org.bson.types.ObjectId;
+import org.springframework.data.repository.CrudRepository;
+
+import com.capitalone.dashboard.model.CoverityScan;
+
+public interface CoverityScanRepository extends CrudRepository<CoverityScan, ObjectId> {
+
+    CoverityScan findByCollectorItemIdAndTimestamp(ObjectId collectorItemId, long timestamp);
+
+    List<CoverityScan> findByCollectorItemId(ObjectId collectorItemId);
+}

--- a/collectors/security/coverity/src/main/resources/logback.xml
+++ b/collectors/security/coverity/src/main/resources/logback.xml
@@ -1,0 +1,29 @@
+<configuration>
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <!-- encoders are assigned the type
+         ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+    <encoder>
+      <pattern>%d %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+  <appender name="ROLLING" class="ch.qos.logback.core.rolling.RollingFileAppender">
+    <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+      <!-- rollover daily -->
+      <fileNamePattern>logs/coverity/coverity-security-collector-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+      <timeBasedFileNamingAndTriggeringPolicy
+        class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
+        <!-- or whenever the file size reaches 20MB -->
+        <maxFileSize>20MB</maxFileSize>
+      </timeBasedFileNamingAndTriggeringPolicy>
+      <maxHistory>30</maxHistory>
+    </rollingPolicy>
+    <encoder>
+      <pattern>%d %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="INFO">
+    <appender-ref ref="ROLLING"/>
+    <appender-ref ref="STDOUT"/>
+  </root>
+</configuration>

--- a/collectors/security/coverity/src/test/java/com/capitalone/dashboard/collector/CoverityCollectorTaskTest.java
+++ b/collectors/security/coverity/src/test/java/com/capitalone/dashboard/collector/CoverityCollectorTaskTest.java
@@ -1,0 +1,440 @@
+package com.capitalone.dashboard.collector;
+
+import static java.util.stream.Collectors.toList;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyCollection;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.anyLong;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.GregorianCalendar;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.xml.datatype.DatatypeConfigurationException;
+import javax.xml.datatype.DatatypeFactory;
+import javax.xml.datatype.XMLGregorianCalendar;
+
+import org.bson.types.ObjectId;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Matchers;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.scheduling.TaskScheduler;
+
+import com.capitalone.dashboard.collector.coverity.soap.CoveritySoapClient;
+import com.capitalone.dashboard.model.CodeQuality;
+import com.capitalone.dashboard.model.CollectorItem;
+import com.capitalone.dashboard.model.CollectorType;
+import com.capitalone.dashboard.model.Component;
+import com.capitalone.dashboard.model.Configuration;
+import com.capitalone.dashboard.model.CoverityCollector;
+import com.capitalone.dashboard.model.CoverityProject;
+import com.capitalone.dashboard.model.CoverityScan;
+import com.capitalone.dashboard.repository.CodeQualityRepository;
+import com.capitalone.dashboard.repository.ComponentRepository;
+import com.capitalone.dashboard.repository.ConfigurationRepository;
+import com.capitalone.dashboard.repository.CoverityCollectorRepository;
+import com.capitalone.dashboard.repository.CoverityProjectRepository;
+import com.capitalone.dashboard.repository.CoverityScanRepository;
+
+import coverity.ws.configuration.CovRemoteServiceException_Exception;
+import coverity.ws.configuration.ProjectDataObj;
+import coverity.ws.configuration.ProjectIdDataObj;
+import coverity.ws.configuration.StreamDataObj;
+import coverity.ws.configuration.StreamIdDataObj;
+import coverity.ws.defect.AttributeDefinitionIdDataObj;
+import coverity.ws.defect.AttributeValueIdDataObj;
+import coverity.ws.defect.DefectStateAttributeValueDataObj;
+import coverity.ws.defect.MergedDefectDataObj;
+import coverity.ws.defect.MergedDefectsPageDataObj;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CoverityCollectorTaskTest {
+    @Mock private TaskScheduler taskScheduler;
+    @Mock private CoverityCollectorRepository covCollectorRepo;
+    @Mock private CoverityProjectRepository covProjectRepo;
+    @Mock private CoverityScanRepository covScanRepo;
+    @Mock private CoveritySettings covSettings;
+    @Mock private ComponentRepository componentRepo;
+    @Mock private ConfigurationRepository configurationRepo;
+    @Mock private CoveritySoapClient covClient;
+    @Mock private CodeQualityRepository codeQualityRepo;
+
+    @InjectMocks private CoverityCollectorTask task;
+
+    private static final String
+        TEST_URL = "http://mockServer.com:8080/ssc",
+        TEST_USR = "test",
+        TEST_PWD = "testpwd",
+        TEST_PROJ_NAME = "QUUX",
+        TEST_STREAM = "styx";
+
+    private static final long TEST_PROJ_KEY = 1776l;
+
+    @Test
+    public void collect_noBuildServers_nothingAdded() {
+
+        when(configurationRepo.findByCollectorName(any()))
+        	.thenReturn(new Configuration());
+
+        task.collect(new CoverityCollector());
+
+        verifyZeroInteractions(covScanRepo);
+        verifyZeroInteractions(codeQualityRepo);
+    }
+
+    @Test
+    public void collector_register() {
+
+        when(configurationRepo.findByCollectorName(any())).thenReturn(configuration());
+
+        CoverityCollector collector = task.getCollector();
+
+        assertThat(collector.getCoverityServers().size(), is(1));
+        assertThat(collector.getCoverityServers().get(0), is(TEST_URL));
+        verifyZeroInteractions(codeQualityRepo);
+    }
+
+    @Test
+    public void noDuplicateCoverityScanReports() throws Exception {
+
+    	when(configurationRepo.findByCollectorName(any())).thenReturn(configuration());
+        // this mocking is just to prevent null exceptions
+        when(componentRepo.findAll()).thenReturn(components());
+        when(covProjectRepo.findByCollectorIdIn(any()))
+            .thenReturn(fromExistingWsdlProject());
+        when(covProjectRepo.findEnabledProjects(any(ObjectId.class), anyString()))
+            .thenReturn(fromExistingWsdlProject());
+        when(covClient.getAllProjects(TEST_URL))
+            .thenReturn(wsdlProject());
+        // duplication is simulated by returning a "matching" persisted instance
+        when(codeQualityRepo.findByCollectorItemIdAndTimestamp(any(ObjectId.class), anyLong()))
+            .thenReturn(new CodeQuality());
+        when(covClient.getSecurityDefectsForStream(anyString(), any(), anyInt()))
+            .thenReturn(getStreamDefects(TEST_STREAM));
+
+        task.collect(coverityCollector(configuration()));
+
+        verify(codeQualityRepo, never()).save(any(CodeQuality.class));
+        verify(covScanRepo, never()).save(any(CoverityScan.class));
+    }
+
+    @Test
+    public void scanReportTest() throws Exception {
+
+        when(componentRepo.findAll()).thenReturn(components());
+        when(configurationRepo.findByCollectorName(any())).thenReturn(configuration());
+        when(covClient.getAllProjects(anyString())).thenReturn(wsdlProject());
+        when(covClient.getSecurityDefectsForStream(anyString(), any(), anyInt()))
+            .thenReturn(getStreamDefects(TEST_STREAM));
+        when(covProjectRepo.findEnabledProjects(any(ObjectId.class), anyString()))
+            .thenReturn(fromExistingWsdlProject());
+        // simulating new coverity scan data
+        when(covScanRepo.findByCollectorItemIdAndTimestamp(any(ObjectId.class), anyLong()))
+            .thenReturn(null);
+        when(codeQualityRepo.findByCollectorItemIdAndTimestamp(any(ObjectId.class), anyLong()))
+            .thenReturn(null);
+
+        task.collect(coverityCollector(configuration()));
+
+        verify(codeQualityRepo, times(1)).save(anyCollection());
+        verify(covScanRepo, times(1)).save(anyCollection());
+    }
+
+    @Test
+    public void noScanReportTest() throws Exception {
+
+        when(componentRepo.findAll()).thenReturn(components());
+        when(configurationRepo.findByCollectorName(any())).thenReturn(configuration3());
+        when(covClient.getAllProjects(anyString()))
+            .thenReturn(wsdlProject())
+            .thenThrow(new CovRemoteServiceException_Exception("msg", null));
+        // simulate that something goes wrong...
+        when(covClient.getSecurityDefectsForStream(anyString(), any(), anyInt()))
+            .thenThrow(new coverity.ws.defect.CovRemoteServiceException_Exception("msg", null));
+        when(covProjectRepo.findEnabledProjects(any(ObjectId.class), anyString()))
+            .thenReturn(fromExistingWsdlProject());
+        when(codeQualityRepo.findByCollectorItemIdAndTimestamp(any(ObjectId.class), anyLong()))
+            .thenReturn(new CodeQuality());
+
+        task.collect(coverityCollector(configuration3()));
+
+        verify(codeQualityRepo, never()).save(any(CodeQuality.class));
+        verify(covScanRepo, never()).save(any(CoverityScan.class));
+    }
+
+    @Test public void detectExistingCodeQuality_thenDoNotSave() throws Exception {
+
+        when(componentRepo.findAll()).thenReturn(components());
+        when(configurationRepo.findByCollectorName(any())).thenReturn(configuration());
+
+        when(covProjectRepo.findByCollectorIdIn(any()))
+            .thenReturn(fromExistingWsdlProject());
+
+        when(covClient.getAllProjects(anyString()))
+            .thenReturn(wsdlProject());
+
+        when(covProjectRepo.findEnabledProjects(any(ObjectId.class), anyString()))
+            .thenReturn(fromExistingWsdlProject());
+
+        when(covScanRepo.findByCollectorItemIdAndTimestamp(any(ObjectId.class), anyLong()))
+            .thenReturn(null);
+
+        MergedDefectsPageDataObj defects = getStreamDefects(TEST_STREAM);
+        defects.setTotalNumberOfRecords(0);
+        defects.getMergedDefects().clear();
+
+        when(covClient.getSecurityDefectsForStream(anyString(), any(), anyInt()))
+            .thenReturn(defects);
+
+        when(codeQualityRepo.findByCollectorItemIdOrderByTimestampDesc(any()))
+            .thenReturn(Arrays.asList(new CodeQuality(), new CodeQuality()));
+
+        task.collect(coverityCollector(configuration()));
+
+        verify(codeQualityRepo, never()).save(any(CodeQuality.class));
+        verify(covScanRepo, never()).save(any(CoverityScan.class));
+    }
+
+    @Test
+    public void removeUnwantedJobsTest() throws Exception {
+
+        when(componentRepo.findAll()).thenReturn(components());
+        when(configurationRepo.findByCollectorName(any())).thenReturn(configuration());
+        when(covClient.getAllProjects(anyString()))
+            .thenReturn(Collections.emptyList()); // no projects on server
+        when(covProjectRepo.findByCollectorIdIn(Matchers.anyListOf(ObjectId.class)))
+            .thenReturn(fromExistingWsdlProject()); // dead project
+        when(covProjectRepo.findEnabledProjects(any(ObjectId.class), anyString()))
+            .thenReturn(new ArrayList<>());
+
+        task.collect(coverityCollector(configuration()));
+
+        verify(covProjectRepo, atLeastOnce()).delete(Matchers.anyListOf(CoverityProject.class));
+    }
+
+    @Test
+    public void addNewProjectsTest() throws Exception {
+
+    	CoverityProject cp = new CoverityProject();
+    	cp.setInstanceUrl(TEST_URL);
+
+        when(covClient.getAllProjects(anyString()))
+            .thenReturn(wsdlProject());
+        when(covProjectRepo.findByCollectorIdIn(Matchers.anySetOf(ObjectId.class)))
+            .thenReturn(Arrays.asList(cp));
+        when(componentRepo.findAll()).thenReturn(components());
+        when(configurationRepo.findByCollectorName(any())).thenReturn(configuration());
+
+        task.collect(coverityCollector(configuration()));
+
+        verify(covProjectRepo, atLeastOnce()).save(Matchers.anyListOf(CoverityProject.class));
+    }
+
+    @Test
+    public void removeDeadProjects() throws Exception {
+
+        CoverityProject zombie = new CoverityProject();
+        CoverityProject garbage = new CoverityProject();
+
+        zombie.setEnabled(true);
+        zombie.setInstanceUrl("dummy");
+
+        garbage.setEnabled(false);
+        garbage.setInstanceUrl("dummy2");
+
+        when(covClient.getAllProjects(TEST_URL))
+            .thenReturn(wsdlProject());
+        when(covProjectRepo.findByCollectorIdIn(Matchers.anySetOf(ObjectId.class)))
+            .thenReturn(Arrays.asList(
+                        zombie, garbage
+                    ));
+
+        when(componentRepo.findAll()).thenReturn(components());
+        when(configurationRepo.findByCollectorName(any())).thenReturn(configuration());
+
+        task.collect(coverityCollector(configuration()));
+
+        verify(covProjectRepo, atLeastOnce()).delete(Matchers.anyListOf(CoverityProject.class));
+    }
+
+    private MergedDefectsPageDataObj getStreamDefects(String stream) throws DatatypeConfigurationException {
+
+        MergedDefectsPageDataObj d = new MergedDefectsPageDataObj();
+
+        d.setTotalNumberOfRecords(1);
+        d.getMergedDefects().add(new MergedDefectDataObj());
+        d.getMergedDefects().get(0).setLastDetectedStream(stream);
+        d.getMergedDefects().get(0).setCid(333L);
+
+        d.getMergedDefects().get(0).getDefectStateAttributeValues()
+            .add(new DefectStateAttributeValueDataObj());
+
+        AttributeDefinitionIdDataObj
+            sevAttrName = new AttributeDefinitionIdDataObj(),
+            sevScoreAttrName = new AttributeDefinitionIdDataObj();
+        sevAttrName.setName("CVSS_Severity");
+        sevScoreAttrName.setName("CVSS_Score");
+        AttributeValueIdDataObj
+            sevAttrValue = new AttributeValueIdDataObj(),
+            sevScoreValue = new AttributeValueIdDataObj();
+        sevAttrValue.setName("Critical");
+        sevScoreValue.setName("9.8");
+
+        d.getMergedDefects().get(0).getDefectStateAttributeValues().get(0)
+            .setAttributeDefinitionId(sevAttrName);
+        d.getMergedDefects().get(0).getDefectStateAttributeValues().get(0)
+            .setAttributeValueId(sevAttrValue);
+
+        d.getMergedDefects().get(0).setDisplayType("null variable");
+        d.getMergedDefects().get(0).setFilePathname("anyProgramWrittenIn.java");
+
+        GregorianCalendar gc  = new GregorianCalendar(10, 10, 10);
+        XMLGregorianCalendar xgc = DatatypeFactory.newInstance().newXMLGregorianCalendar(gc);
+
+        d.getMergedDefects().get(0).setLastDetected(xgc);
+
+        return d;
+    }
+
+    private List<CoverityProject> fromExistingWsdlProject() throws Exception {
+
+        List<CoverityProject> cps = new ArrayList<>();
+
+        for (ProjectDataObj soapProjObj : wsdlProject()) {
+            CoverityProject covProj = new CoverityProject();
+
+            covProj.setCollectorId(new ObjectId());
+            covProj.setInstanceUrl(TEST_URL);
+
+            String stream = soapProjObj.getStreams().get(0).getId().getName();
+
+            covProj.setDescription(soapProjObj.getId().getName(), stream);
+            covProj.setProjectKey(soapProjObj.getProjectKey());
+            covProj.setDateCreated(soapProjObj.getDateCreated().toGregorianCalendar().getTimeInMillis() / 1000);
+            covProj.setDateModified(soapProjObj.getDateModified().toGregorianCalendar().getTimeInMillis() / 1000);
+
+            cps.add(covProj);
+        }
+
+        return cps;
+    }
+
+    private List<ProjectDataObj> wsdlProject() throws Exception {
+
+        ProjectDataObj wsdlProj = new ProjectDataObj();
+
+        wsdlProj.setId(new ProjectIdDataObj());
+        wsdlProj.getId().setName(TEST_PROJ_NAME);
+
+        wsdlProj.setProjectKey(TEST_PROJ_KEY);
+
+        GregorianCalendar gc  = new GregorianCalendar(10, 10, 10);
+        XMLGregorianCalendar xgc = DatatypeFactory.newInstance().newXMLGregorianCalendar(gc);
+        wsdlProj.setDateCreated(xgc);
+        wsdlProj.setDateModified(xgc);
+
+        wsdlProj.getStreams().add(new StreamDataObj());
+        wsdlProj.getStreams().get(0).setId(new StreamIdDataObj());
+        wsdlProj.getStreams().get(0).getId().setName(TEST_STREAM);
+
+        return Arrays.asList(wsdlProj);
+    }
+
+    /**
+     * Helper method to create configuration object with a details for a fake Coverity server
+     * @return Configuration with Coverity server
+     */
+    private Configuration configuration() {
+
+        Configuration config = new Configuration();
+        config.setCollectorName(CoverityCollector.NICE_NAME);
+        
+        Map<String,String> coverityServer = new HashMap<>();
+        coverityServer.put("url", TEST_URL);
+        coverityServer.put("userName", TEST_USR);
+        coverityServer.put("password", TEST_PWD);
+
+        config.getInfo().add(coverityServer);
+
+        return config;
+    }
+
+    private Configuration configuration3() {
+
+        Configuration config = new Configuration();
+        config.setCollectorName(CoverityCollector.NICE_NAME);
+        
+        Map<String,String> coverityServer = new HashMap<>();
+
+        coverityServer.put("url", TEST_URL);
+        coverityServer.put("userName", TEST_USR);
+        coverityServer.put("password", TEST_PWD);
+
+        config.getInfo().add(coverityServer);
+        
+        // config #2
+        coverityServer = new HashMap<>();
+
+        coverityServer.put("url", TEST_URL);
+        coverityServer.put("userName", TEST_USR);
+        coverityServer.put("password", TEST_PWD);
+
+        config.getInfo().add(coverityServer);
+
+        // config #3
+        coverityServer = new HashMap<>();
+
+        coverityServer.put("url", "example.malformed");
+        coverityServer.put("userName", TEST_USR);
+        coverityServer.put("password", TEST_PWD);
+
+        config.getInfo().add(coverityServer);
+        
+        return config;
+    }
+
+    private List<com.capitalone.dashboard.model.Component> components() {
+
+        com.capitalone.dashboard.model.Component c = new Component();
+        c.setId(new ObjectId());
+        c.setName("COMPONENT1");
+        c.setOwner("JOHN");
+
+        CollectorItem ci = new CollectorItem();
+        ci.setId(new ObjectId());
+        ci.setCollectorId(new ObjectId());
+
+        c.getCollectorItems().put(
+                CollectorType.StaticSecurityScan,
+                Arrays.asList(ci));
+
+        return Arrays.asList(c);
+    }
+
+    private CoverityCollector coverityCollector(Configuration config) {
+
+        List<String> serverUrls = config.getInfo().stream()
+                .map(server -> server.get("url")).collect(toList());
+
+        CoverityCollector coll = CoverityCollector.prototype(serverUrls);
+        coll.setId(new ObjectId(new java.util.Date()));
+
+        return coll;
+    }
+}

--- a/collectors/security/coverity/src/test/java/com/capitalone/dashboard/collector/coverity/soap/CoveritySoapClientTest.java
+++ b/collectors/security/coverity/src/test/java/com/capitalone/dashboard/collector/coverity/soap/CoveritySoapClientTest.java
@@ -1,0 +1,104 @@
+package com.capitalone.dashboard.collector.coverity.soap;
+
+import static java.util.Collections.emptyList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.doReturn;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import javax.xml.ws.WebServiceException;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Spy;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import coverity.ws.configuration.ConfigurationServiceService;
+import coverity.ws.configuration.ProjectDataObj;
+import coverity.ws.configuration.ProjectFilterSpecDataObj;
+import coverity.ws.defect.DefectServiceService;
+import coverity.ws.defect.MergedDefectsPageDataObj;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CoveritySoapClientTest  {
+
+    @Spy private CoveritySoapClient clientSpy;
+
+    private static final String URL_TEST = "http://mockServer.com:8080/ssc";
+
+    @Before
+    public void init() {
+        clientSpy.setServerDetails(covServerDetails());
+    }
+
+    @Test
+    public void noProjectsInCoverityReturnsEmptyList() throws Exception {
+
+        doReturn(emptyList())
+            .when(clientSpy)
+            .getProjectsStubbable(any(ProjectFilterSpecDataObj.class));
+        // prevent test from trying to "ping" for wsdl at mock server url
+        doReturn(new ConfigurationServiceService())
+            .when(clientSpy)
+            .stubbableNewCofigSrvcSrvc(anyString());
+
+    	List<ProjectDataObj> list = clientSpy.getAllProjects(URL_TEST);
+    	assertTrue(list.isEmpty());
+    }
+
+    @Test(expected = WebServiceException.class)
+    public void noCredentialsForUnknownInstance_getProjects() throws Exception {
+    	clientSpy.getAllProjects("http://example.com");
+    }
+
+    @Test
+    public void projectWithNoDefectsReturnsEmptyList() throws Exception {
+
+        MergedDefectsPageDataObj dummy = new MergedDefectsPageDataObj();
+        dummy.setTotalNumberOfRecords(0);
+
+        doReturn(dummy)
+            .when(clientSpy)
+            .getMergedDefectsForStreamsStubbable(any(), any(), any(), any());
+        // prevent test from trying to "ping" for wsdl at mock server url
+        doReturn(new DefectServiceService())
+            .when(clientSpy)
+            .stubbableNewDefectSrvcSrvc(anyString());
+
+        MergedDefectsPageDataObj defectPage = clientSpy.getSecurityDefectsForStream(URL_TEST, "app", 0);
+
+        assertEquals("Expected zero records", (Integer) 0, defectPage.getTotalNumberOfRecords());
+    }
+
+    @Test(expected = WebServiceException.class)
+    public void noCredentialsForUnknownInstance_getDefects() throws Exception {
+        clientSpy.getSecurityDefectsForStream("http://example.com", "dummy", 0);
+    }
+
+    /**
+     * Helper method to create details for a fake Coverity server
+     * @return Configuration with Coverity server
+     */
+    private Set<Map<String,String>> covServerDetails() {
+
+        Set<Map<String,String>> coverityServersCollection = new HashSet<>();
+
+        Map<String,String> coverityServer = new HashMap<>();
+
+        coverityServer.put("url", URL_TEST);
+        coverityServer.put("userName", "test");
+        coverityServer.put("password", "testpwd");
+
+        coverityServersCollection.add(coverityServer);
+
+        return coverityServersCollection;
+    }
+}


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/41026947/53523575-cb36f400-3aa2-11e9-9890-f817871de81f.png)

Collector for security issues from Coverity for the security tab of the quality widget. The security tab is configured with a Coverity Stream and its corresponding Coverity Project.

UI changes:
Order rows in security tab by severity
Show status icons for security tab
