### PR TITLE
Jira: Add in capability for multiple story ids

### DIFF
--- a/collectors/feature/jira/src/main/java/com/capitalone/dashboard/collector/DefaultJiraClient.java
+++ b/collectors/feature/jira/src/main/java/com/capitalone/dashboard/collector/DefaultJiraClient.java
@@ -37,6 +37,7 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -361,7 +362,7 @@ public class DefaultJiraClient implements JiraClient {
                         return;
                     }
 
-                    if (!StringUtils.isEmpty(featureSettings.getJiraStoryId()) && featureSettings.getJiraStoryId().equals(type)) {
+                    if (featureSettings.getJiraStoryIds().length > 0 && Arrays.asList(featureSettings.getJiraStoryIds()).contains(type)) {
                         Feature feature = getFeature((JSONObject) issue, board);
                         String epicId = feature.getsEpicID();
                         if (!StringUtils.isEmpty(epicId)) {

--- a/collectors/feature/jira/src/main/java/com/capitalone/dashboard/collector/FeatureSettings.java
+++ b/collectors/feature/jira/src/main/java/com/capitalone/dashboard/collector/FeatureSettings.java
@@ -94,7 +94,7 @@ public class FeatureSettings {
 	 * via the following URI
 	 *  https://[your-jira-domain-name]/rest/api/2/issuetype
 	 */
-	private String jiraStoryId;
+	private String[] jiraStoryIds;
 	/**
 	 * In Jira, your instance will have its own Id for the Epic
 	 * <p>
@@ -273,12 +273,12 @@ public class FeatureSettings {
 		this.jiraBoardAsTeam = jiraBoardAsTeam;
 	}
 
-	public String getJiraStoryId() {
-		return jiraStoryId;
+	public String[] getJiraStoryIds() {
+		return jiraStoryIds;
 	}
 
-	public void setJiraStoryId(String jiraStoryId) {
-		this.jiraStoryId = jiraStoryId;
+	public void setJiraStoryIds(String[] jiraStoryIds) {
+		this.jiraStoryIds = jiraStoryIds;
 	}
 
 	public String getJiraEpicId() {

--- a/collectors/feature/jira/src/test/java/com/capitalone/dashboard/config/TestConfig.java
+++ b/collectors/feature/jira/src/test/java/com/capitalone/dashboard/config/TestConfig.java
@@ -28,7 +28,7 @@ public class TestConfig {
         settings.setJiraStoryPointsFieldName("customfield_10004");
         settings.setMaxNumberOfFeaturesPerBoard(10000);
         settings.setJiraEpicId("6");
-        settings.setJiraStoryId("7");
+        settings.setJiraStoryIds(new String[]{"7","8"});
 
 
         return settings;


### PR DESCRIPTION
I was having issues with getting all the different story types with the only one story id from my companies jira instance. So I added the capability for multiple story ids.