### PR TITLE
closes #2892 - Fix for Jira Collector requiring manual insert for Issue Type IDs

### DIFF
--- a/collectors/feature/jira/src/main/java/com/capitalone/dashboard/collector/DefaultJiraClient.java
+++ b/collectors/feature/jira/src/main/java/com/capitalone/dashboard/collector/DefaultJiraClient.java
@@ -314,9 +314,7 @@ public class DefaultJiraClient implements JiraClient {
                 if(list.contains(name)){
                     issueTypes.put(name, id);
                 }
-
             }
-
 
         } catch (ParseException pe) {
             LOGGER.error("Parser exception when parsing teams", pe);

--- a/collectors/feature/jira/src/main/java/com/capitalone/dashboard/collector/DefaultJiraClient.java
+++ b/collectors/feature/jira/src/main/java/com/capitalone/dashboard/collector/DefaultJiraClient.java
@@ -68,12 +68,13 @@ public class DefaultJiraClient implements JiraClient {
     private static final String ISSUE_BY_PROJECT_REST_SUFFIX_BY_DATE = "rest/api/2/search?jql=project=%s and issueType in ('%s') and updatedDate>='%s'&fields=%s&startAt=%s";
     private static final String ISSUE_BY_BOARD_REST_SUFFIX_BY_DATE = "rest/agile/1.0/board/%s/issue?jql=issueType in ('%s') and updatedDate>='%s'&fields=%s&startAt=%s";
     private static final String EPIC_REST_SUFFIX = "rest/agile/1.0/issue/%s";
-
+    private static final String ISSUE_TYPES_REST_SUFFIX = "rest/api/2/issuetype";
     private static final String ISSUE_BY_BOARD_FULL_REFRESH_REST_SUFFIX = "rest/agile/1.0/%s/%s/issue?jql=issueType in ('%s') and updatedDate>='%s'&fields=id&startAt=%s";
 
     private static final String STATIC_ISSUE_FIELDS = "id,key,issuetype,status,summary,created,updated,project,issuelinks,assignee,sprint,epic,aggregatetimeoriginalestimate,timeoriginalestimate";
 
     private static final String DEFAULT_ISSUE_TYPES = "Story,Epic";
+    private static final String EPIC_ISSUE_TYPE = "Epic";
     private static final int JIRA_BOARDS_PAGING = 50;
     private final FeatureSettings featureSettings;
     private final RestOperations restOperations;
@@ -247,13 +248,13 @@ public class DefaultJiraClient implements JiraClient {
      * @return List of Feature
      */
     @Override
-    public FeatureEpicResult getIssues(Team board) {
+    public FeatureEpicResult getIssues(Team board, Map<String, String> issueTypeIds) {
         Map<String, Epic> epicMap = new HashMap<>();
         FeatureEpicResult featureEpicResult = new FeatureEpicResult();
 
         String lookBackDate = getUpdatedSince(board.getLastCollected());
 
-        String issueTypes = featureSettings.getJiraIssueTypeNames() == null ? DEFAULT_ISSUE_TYPES : String.join(",", featureSettings.getJiraIssueTypeNames());
+        String issueTypes = getIssueTypes();
 
         List<Feature> features = new ArrayList<>();
         boolean isLast = false;
@@ -264,7 +265,7 @@ public class DefaultJiraClient implements JiraClient {
                     + ISSUE_BY_BOARD_REST_SUFFIX_BY_DATE;
             url = String.format(url, board.getTeamId(), issueTypes.replaceAll(",", "','"), lookBackDate, issueFields, startAt);
             try {
-                IssueResult temp = getFeaturesFromQueryURL(url, epicMap, board);
+                IssueResult temp = getFeaturesFromQueryURL(url, epicMap, board, issueTypeIds);
 
                 if (temp.getTotal() >= featureSettings.getMaxNumberOfFeaturesPerBoard()){
                     LOGGER.info("Board: \'" + board.getName() + "\' passes the feature max limit at " + temp.getTotal() + " features. Skipping..");
@@ -292,6 +293,38 @@ public class DefaultJiraClient implements JiraClient {
         featureEpicResult.getEpicList().addAll(epicMap.values());
         return featureEpicResult;
     }
+    @Override
+    public Map<String, String> getJiraIssueTypeIds() {
+        Map<String, String> issueTypes = new HashMap<>();
+        try {
+            String url = featureSettings.getJiraBaseUrl() + (featureSettings.getJiraBaseUrl().endsWith("/") ? "" : "/")
+                    + ISSUE_TYPES_REST_SUFFIX;
+            ResponseEntity<String> responseEntity = makeRestCall(url);
+            String responseBody = responseEntity.getBody();
+
+            JSONArray issueTypesArray = (JSONArray) parser.parse(responseBody);
+            if (issueTypesArray == null) {
+                throw new HygieiaException("Unable to get Issue Type IDs from: " + url, HygieiaException.INVALID_CONFIGURATION);
+            }
+            List<String> list = new ArrayList<>(Arrays.asList( getIssueTypes().split(",")));
+            for (Object obj : issueTypesArray) {
+                JSONObject jo = (JSONObject) obj;
+                String name = getString(jo,"name");
+                String id = getString(jo,"id");
+                if(list.contains(name)){
+                    issueTypes.put(name, id);
+                }
+
+            }
+
+
+        } catch (ParseException pe) {
+            LOGGER.error("Parser exception when parsing teams", pe);
+        } catch (HygieiaException e) {
+            LOGGER.error("Error in calling JIRA API", e);
+        }
+        return issueTypes;
+    }
 
     /**
      * Get list of Features (Issues in Jira terms) given a project.
@@ -300,13 +333,13 @@ public class DefaultJiraClient implements JiraClient {
      * @return List of Feature
      */
     @Override
-    public FeatureEpicResult getIssues(Scope project) {
+    public FeatureEpicResult getIssues(Scope project, Map<String, String> issueTypeIds) {
         Map<String, Epic> epicMap = new HashMap<>();
         FeatureEpicResult featureEpicResult = new FeatureEpicResult();
 
         String lookBackDate = getUpdatedSince(project.getLastCollected());
 
-        String issueTypes = featureSettings.getJiraIssueTypeNames() == null ? DEFAULT_ISSUE_TYPES : String.join(",", featureSettings.getJiraIssueTypeNames());
+        String issueTypes = getIssueTypes();
 
         List<Feature> features = new ArrayList<>();
 
@@ -319,7 +352,7 @@ public class DefaultJiraClient implements JiraClient {
                         + ISSUE_BY_PROJECT_REST_SUFFIX_BY_DATE;
                 url = String.format(url, project.getpId(), issueTypes.replaceAll(",", "','"), lookBackDate, issueFields, startAt);
 
-                IssueResult temp = getFeaturesFromQueryURL(url, epicMap, null);
+                IssueResult temp = getFeaturesFromQueryURL(url, epicMap, null, issueTypeIds);
 
                 features.addAll(temp.getFeatures());
                 isLast = temp.getTotal() == features.size() || CollectionUtils.isEmpty(temp.getFeatures());
@@ -336,7 +369,7 @@ public class DefaultJiraClient implements JiraClient {
     }
 
 
-    private IssueResult getFeaturesFromQueryURL(String url, Map<String, Epic> epicMap, Team board) throws HygieiaException, ParseException {
+    private IssueResult getFeaturesFromQueryURL(String url, Map<String, Epic> epicMap, Team board, Map<String, String> issueTypeIds) throws HygieiaException, ParseException {
         IssueResult result = new IssueResult();
         try {
             ResponseEntity<String> responseEntity = makeRestCall(url);
@@ -357,12 +390,16 @@ public class DefaultJiraClient implements JiraClient {
                     JSONObject issueJson = (JSONObject) issue;
                     String type = getIssueType(issueJson);
 
-                    if (!StringUtils.isEmpty(featureSettings.getJiraEpicId()) && featureSettings.getJiraEpicId().equals(type)) {
+                    if (!StringUtils.isEmpty(issueTypeIds.get(EPIC_ISSUE_TYPE)) && issueTypeIds.get(EPIC_ISSUE_TYPE).equals(type)) {
                         saveEpic(issueJson, epicMap, true);
                         return;
                     }
 
-                    if (featureSettings.getJiraStoryIds().length > 0 && Arrays.asList(featureSettings.getJiraStoryIds()).contains(type)) {
+                    boolean isValidIssueType = !issueTypeIds.get(EPIC_ISSUE_TYPE).equals(type)
+                            && !CollectionUtils.isEmpty(issueTypeIds.values())
+                            && issueTypeIds.values().contains(type);
+
+                    if (isValidIssueType) {
                         Feature feature = getFeature((JSONObject) issue, board);
                         String epicId = feature.getsEpicID();
                         if (!StringUtils.isEmpty(epicId)) {
@@ -385,6 +422,13 @@ public class DefaultJiraClient implements JiraClient {
         return getString(issueType, "id");
     }
 
+    /**
+     *  Returns issue types from settings or default values if settings don't exist
+     * @return issue type id string
+     */
+    private String getIssueTypes(){
+        return featureSettings.getJiraIssueTypeNames() == null ? DEFAULT_ISSUE_TYPES : String.join(",", featureSettings.getJiraIssueTypeNames());
+    }
 
     /**
      * Construct Feature object
@@ -724,7 +768,7 @@ public class DefaultJiraClient implements JiraClient {
         boolean isLast = false;
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy/MM/dd HH:mm");
         String updatedDate = LocalDateTime.now().minusDays(featureSettings.getFirstRunHistoryDays()).format(formatter);
-        String issueTypes = featureSettings.getJiraIssueTypeNames() == null ? DEFAULT_ISSUE_TYPES : String.join(",", featureSettings.getJiraIssueTypeNames());
+        String issueTypes = getIssueTypes();
         List<String> result = new ArrayList<>();
         while (!isLast) {
 

--- a/collectors/feature/jira/src/main/java/com/capitalone/dashboard/collector/JiraClient.java
+++ b/collectors/feature/jira/src/main/java/com/capitalone/dashboard/collector/JiraClient.java
@@ -12,9 +12,9 @@ import java.util.Set;
 
 public interface JiraClient {
 
-	FeatureEpicResult getIssues(Team board);
+	FeatureEpicResult getIssues(Team board, Map<String, String> issueTypeIds);
 
-	FeatureEpicResult getIssues(Scope project);
+	FeatureEpicResult getIssues(Scope project, Map<String, String> issueTypeIds);
 
 	Set<Scope> getProjects();
 
@@ -25,4 +25,6 @@ public interface JiraClient {
 	Epic getEpic(String epicKey, Map<String, Epic> epicMap);
 
 	List<String> getAllIssueIds(String id, JiraMode mode);
+
+	Map<String, String> getJiraIssueTypeIds();
 }

--- a/collectors/feature/jira/src/test/java/com/capitalone/dashboard/collector/DefaultJiraClientTest.java
+++ b/collectors/feature/jira/src/test/java/com/capitalone/dashboard/collector/DefaultJiraClientTest.java
@@ -27,7 +27,9 @@ import org.springframework.web.client.RestOperations;
 import java.io.IOException;
 import java.net.URL;
 import java.text.ParseException;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -66,8 +68,10 @@ public class DefaultJiraClientTest {
         doReturn(new ResponseEntity<>(getExpectedJSON("response/epicresponse.json"), HttpStatus.OK)).when(rest).exchange(contains("rest/agile/1.0/issue/"), eq(HttpMethod.GET), Matchers.any(HttpEntity.class), eq(String.class));
 
         doReturn(new ResponseEntity<>(getExpectedJSON("response/issueresponse-combo.json"), HttpStatus.OK)).when(rest).exchange(contains("rest/agile/1.0/board/"+team.getTeamId()), eq(HttpMethod.GET), Matchers.any(HttpEntity.class), eq(String.class));
-
-        FeatureEpicResult featureEpicResult = defaultJiraClient.getIssues(team);
+        Map<String, String> issueTypeIds = new HashMap<>();
+        issueTypeIds.put("Epic", "6");
+        issueTypeIds.put("Story", "7");
+        FeatureEpicResult featureEpicResult = defaultJiraClient.getIssues(team, issueTypeIds);
         assertThat(featureEpicResult.getEpicList().size()).isEqualTo(1);
         assertThat(featureEpicResult.getFeatureList().size()).isEqualTo(1);
     }

--- a/collectors/feature/jira/src/test/java/com/capitalone/dashboard/collector/FeatureCollectorTaskTest.java
+++ b/collectors/feature/jira/src/test/java/com/capitalone/dashboard/collector/FeatureCollectorTaskTest.java
@@ -21,9 +21,6 @@ import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 import org.apache.commons.io.IOUtils;
 import org.bson.types.ObjectId;
-import org.json.simple.JSONObject;
-import org.json.simple.parser.JSONParser;
-import org.json.simple.parser.ParseException;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -51,8 +48,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.contains;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doReturn;
@@ -104,6 +99,7 @@ public class FeatureCollectorTaskTest {
         featureSettings.setCollectorItemOnlyUpdate(false);
         featureCollectorTask = new FeatureCollectorTask(null,featureRepository,teamRepository,projectRepository,featureCollectorRepository,featureSettings,defaultJiraClient, featureBoardRepository);
 
+        doReturn(new ResponseEntity<>(getExpectedJSON("response/issuetype.json"), HttpStatus.OK)).when(rest).exchange(contains("rest/api/2/issuetype"), eq(HttpMethod.GET), Matchers.any(HttpEntity.class), eq(String.class));
         featureCollector = featureCollectorTask.getCollector();
         featureCollector.setId(new ObjectId("5c38f2f087cd1f53ca81bd3d"));
     }

--- a/collectors/feature/jira/src/test/java/com/capitalone/dashboard/config/TestConfig.java
+++ b/collectors/feature/jira/src/test/java/com/capitalone/dashboard/config/TestConfig.java
@@ -27,8 +27,6 @@ public class TestConfig {
         settings.setJiraEpicIdFieldName("customfield_10003");
         settings.setJiraStoryPointsFieldName("customfield_10004");
         settings.setMaxNumberOfFeaturesPerBoard(10000);
-        settings.setJiraEpicId("6");
-        settings.setJiraStoryIds(new String[]{"7","8"});
 
 
         return settings;

--- a/collectors/feature/jira/src/test/resources/response/issuetype.json
+++ b/collectors/feature/jira/src/test/resources/response/issuetype.json
@@ -1,0 +1,20 @@
+[
+  {
+    "self": "https://jira.com/rest/api/2/issuetype/6",
+    "id": "6",
+    "description": "Created by JIRA Software - do not edit or delete. Issue type for a big user story that needs to be broken down.",
+    "iconUrl": "https://jira.com/secure/viewavatar?size=xsmall&avatarId=12345&avatarType=issuetype",
+    "name": "Epic",
+    "subtask": false,
+    "avatarId": 12345
+  },
+  {
+    "self": "https://jira.com/rest/api/2/issuetype/7",
+    "id": "7",
+    "description": "Created by JIRA Software - do not edit or delete. Issue type for a user story.",
+    "iconUrl": "https://jira.com/secure/viewavatar?size=xsmall&avatarId=123456&avatarType=issuetype",
+    "name": "Story",
+    "subtask": false,
+    "avatarId": 123456
+  },
+]


### PR DESCRIPTION
Removes the requirement for the properties to use:
```
feature.jiraStoryIds[0]=
feature.jiraEpicId=
```

Now the collector only relies on `feature.jiraIssueTypeNames=` to have the issue type names in a comma separated string as usual. 