### PR TITLE
fix: 2609 - Configurable max-result URL variable

### DIFF
--- a/collectors/build/bamboo/docker/properties-builder.sh
+++ b/collectors/build/bamboo/docker/properties-builder.sh
@@ -74,6 +74,9 @@ bamboo.apiKey=${JENKINS_API_KEY}
 #Determines if build console log is collected - defaults to false
 bamboo.saveLog=${JENKINS_SAVE_LOG:-false}
 
+#Specifies the upper limit of plans to fetch. For really large orgs, this may be adjusted to the tens of thousands.
+bamboo.maxPlans=${JENKINS_MAX_PLANS:-2000}
+
 #map the entry localhost so URLS in jenkins resolve properly
 # Docker NATs the real host localhost to 10.0.2.2 when running in docker
 # as localhost is stored in the JSON payload from jenkins we need

--- a/collectors/build/bamboo/src/main/java/com/capitalone/dashboard/collector/BambooSettings.java
+++ b/collectors/build/bamboo/src/main/java/com/capitalone/dashboard/collector/BambooSettings.java
@@ -14,6 +14,7 @@ public class BambooSettings {
 
 
     private String cron;
+    private String maxPlans = "2000"; 
     private boolean saveLog = false;
     private List<String> servers;
     private List<String> niceNames;
@@ -28,6 +29,14 @@ public class BambooSettings {
     public void setCron(String cron) {
         this.cron = cron;
     }
+
+    public String getMaxPlans() { 
+        return maxPlans;
+    }
+
+    public void setMaxPlans(String maxPlans) { 
+        this.maxPlans = maxPlans; 
+    } 
 
     public boolean isSaveLog() {
         return saveLog;


### PR DESCRIPTION
- Uses JENKINS_MAX_PLANS environment variable
- Mapped to bamboo.maxPlans in properties-builder.sh
- Defaults to (current) 2000 if not specified.