### PR TITLE
Fixes: #2929

### DIFF
--- a/api/src/main/java/com/capitalone/dashboard/service/CollectorServiceImpl.java
+++ b/api/src/main/java/com/capitalone/dashboard/service/CollectorServiceImpl.java
@@ -156,7 +156,7 @@ public class CollectorServiceImpl implements CollectorService {
         if (collectorItem==null){
             return Collections.emptyList();
         }
-        Collector collector = collectorRepository.findOne(collectorItem.getId());
+        Collector collector = collectorRepository.findOne(collectorItem.getCollectorId());
         if (collector == null){
             return Collections.emptyList();
         }


### PR DESCRIPTION
Look up tries to use the collectorItemId which causes a null pointer when enabling the score widget and configuring the Feature widget. Updated to look up by the collectorId. 