### PR TITLE
Fix NPE breaking admin page config

### DIFF
--- a/collectors/build/jenkins/src/main/java/com/capitalone/dashboard/collector/HudsonCollectorTask.java
+++ b/collectors/build/jenkins/src/main/java/com/capitalone/dashboard/collector/HudsonCollectorTask.java
@@ -75,19 +75,15 @@ public class HudsonCollectorTask extends CollectorTask<HudsonCollector> {
     @Override
     public HudsonCollector getCollector() {
     	Configuration config = configurationRepository.findByCollectorName("Hudson");
-		if (config != null ) {
+        // Only use Admin Page Jenkins server configuration when available
+        // otherwise use properties file Jenkins server configuration
+        if (config != null ) {
 			config.decryptOrEncrptInfo();
 			// To clear the username and password from existing run and
 			// pick the latest
-			if(hudsonSettings.getServers() == null) {
-				hudsonSettings.setUsernames(new ArrayList<>());
-				hudsonSettings.setApiKeys(new ArrayList<>());
-				hudsonSettings.setServers(new ArrayList<>());
-			} else {
-				hudsonSettings.getUsernames().clear();
-				hudsonSettings.getServers().clear();
-				hudsonSettings.getApiKeys().clear();
-			}
+            hudsonSettings.getUsernames().clear();
+            hudsonSettings.getServers().clear();
+            hudsonSettings.getApiKeys().clear();
 			for (Map<String, String> jenkinsServer : config.getInfo()) {
 				hudsonSettings.getServers().add(jenkinsServer.get("url"));
 				hudsonSettings.getUsernames().add(jenkinsServer.get("userName"));

--- a/collectors/build/jenkins/src/main/java/com/capitalone/dashboard/collector/HudsonSettings.java
+++ b/collectors/build/jenkins/src/main/java/com/capitalone/dashboard/collector/HudsonSettings.java
@@ -1,5 +1,6 @@
 package com.capitalone.dashboard.collector;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import org.springframework.beans.factory.annotation.Value;

--- a/collectors/build/jenkins/src/main/java/com/capitalone/dashboard/collector/HudsonSettings.java
+++ b/collectors/build/jenkins/src/main/java/com/capitalone/dashboard/collector/HudsonSettings.java
@@ -16,12 +16,12 @@ public class HudsonSettings {
 	
     private String cron;
     private boolean saveLog = false;
-    private List<String> servers;
+    private List<String> servers = new ArrayList<>();
     private List<String> niceNames;
     //eg. DEV, QA, PROD etc
-    private List<String> environments;
-    private List<String> usernames;
-    private List<String> apiKeys;
+    private List<String> environments = new ArrayList<>();
+    private List<String> usernames = new ArrayList<>();
+    private List<String> apiKeys = new ArrayList<>();
     private String dockerLocalHostIP; //null if not running in docker on http://localhost
     private int pageSize;
     @Value("${folderDepth:10}")


### PR DESCRIPTION
On the first execution of the Jenkins collector there is a NPE that prevents the collector document for Jenkins from being created. This prevents the General Configuration page from showing the Jenkins configuration.

NPE is avoided by initializing the offending fields in the HudsonSettings class. 