### PR TITLE
Fix - correctly decrypt password when handling default credentials

### DIFF
--- a/collectors/scm/bitbucket/src/main/java/com/capitalone/dashboard/collector/SCMHttpRestClient.java
+++ b/collectors/scm/bitbucket/src/main/java/com/capitalone/dashboard/collector/SCMHttpRestClient.java
@@ -1,5 +1,7 @@
 package com.capitalone.dashboard.collector;
 
+import com.capitalone.dashboard.util.Encryption;
+import com.capitalone.dashboard.util.EncryptionException;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
@@ -35,6 +37,11 @@ public class SCMHttpRestClient {
     if (StringUtils.isEmpty(userId) || StringUtils.isEmpty(password)) {
       id = settings.getUsername();
       secret = settings.getPassword();
+        try {
+            secret = Encryption.decryptString(secret, settings.getKey());
+        } catch (EncryptionException e) {
+            LOG.error(e.getMessage());
+        }
     }
     // Basic Auth only.
     if (!"".equals(id) && !"".equals(secret)) {

--- a/collectors/scm/bitbucket/src/test/java/com/capitalone/dashboard/collector/SCMHttpRestClientTest.java
+++ b/collectors/scm/bitbucket/src/test/java/com/capitalone/dashboard/collector/SCMHttpRestClientTest.java
@@ -1,6 +1,5 @@
 package com.capitalone.dashboard.collector;
 
-import org.apache.commons.codec.binary.Base64;
 import org.apache.http.client.utils.URIBuilder;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -16,13 +15,10 @@ import org.springframework.web.client.RestTemplate;
 
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.nio.charset.StandardCharsets;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
 
 @RunWith(MockitoJUnitRunner.class)
 public class SCMHttpRestClientTest {
@@ -57,15 +53,18 @@ public class SCMHttpRestClientTest {
 
     @Test
     public void makeRestCallAndtestBasicAuthentication() throws URISyntaxException {
-        URI uri = new URIBuilder("https://mycompany.com/rest/api/1.0/xyz/project/rsa").build();
+        URI uri = new URIBuilder(
+                "https://mycompany.com/rest/api/1.0/xyz/project/rsa").build();
 
         given(restTemplate.exchange(uriArgumentCaptor.capture(),
-                httpMethodArgumentCaptor.capture(), httpEntityArgumentCaptor.capture(),
+                httpMethodArgumentCaptor.capture(),
+                httpEntityArgumentCaptor.capture(),
                 classArgumentCaptor.capture()))
                 .willReturn(responseEntity);
 
         //when
-        ResponseEntity<String> stringResponseEntity = scmHttpRestClient.makeRestCall(uri, "user", "password");
+        ResponseEntity<String> stringResponseEntity = scmHttpRestClient
+                .makeRestCall(uri, "user", "password");
 
         //then
         assertNotNull(stringResponseEntity);
@@ -73,9 +72,39 @@ public class SCMHttpRestClientTest {
         assertEquals(uriArgumentCaptor.getValue(), uri);
         HttpEntity<?> entity = httpEntityArgumentCaptor.getValue();
 
-        assertEquals("Basic dXNlcjpwYXNzd29yZA==", entity.getHeaders().get("Authorization").iterator().next());
+        assertEquals("Basic dXNlcjpwYXNzd29yZA==",
+                entity.getHeaders().get("Authorization").iterator().next());
 
     }
 
+    @Test
+    public void makeRestCallAndtestBasicAuthenticationForGlobalCredentials() throws URISyntaxException {
+        URI uri = new URIBuilder(
+                "https://mycompany.com/rest/api/1.0/xyz/project/rsa").build();
+
+        given(restTemplate.exchange(uriArgumentCaptor.capture(),
+                httpMethodArgumentCaptor.capture(),
+                httpEntityArgumentCaptor.capture(),
+                classArgumentCaptor.capture()))
+                .willReturn(responseEntity);
+
+        given(settings.getKey()).willReturn("WI9XFb8cW9bxeS/fwdka0LBXFbqtwvEa");
+        given(settings.getPassword()).willReturn("GASWrg0aNQAbMu0LxTjAhg==");
+        given(settings.getUsername()).willReturn("user");
+
+        //when
+        ResponseEntity<String> stringResponseEntity = scmHttpRestClient
+                .makeRestCall(uri, null, null);
+
+        //then
+        assertNotNull(stringResponseEntity);
+        assertEquals(classArgumentCaptor.getValue(), String.class);
+        assertEquals(uriArgumentCaptor.getValue(), uri);
+        HttpEntity<?> entity = httpEntityArgumentCaptor.getValue();
+
+        assertEquals("Basic dXNlcjpwYXNzd29yZA==",
+                entity.getHeaders().get("Authorization").iterator().next());
+
+    }
 
 }


### PR DESCRIPTION
This PR fixes defect for incorrect decryption of credentials for global credentials for Bitbucket.
There was no unit test covering this scenario so I have added a unit test as well.

cc: @Sbrenthughes @rvema 