### PR TITLE
fix database name in createUser

### DIFF
--- a/mongosrc.js
+++ b/mongosrc.js
@@ -5,7 +5,7 @@ db.createUser(
         user: "dashboarduser",
         pwd: "1qazxSw2",
         roles: [
-            {role: "readWrite", db: "dashboard"}
+            {role: "readWrite", db: "dashboarddb"}
         ]
     })
 db.dummmyCollection.insert({x: 1});


### PR DESCRIPTION
The script is wrong. First it says `use dashboarddb` but then uses dashboard as db name...