### PR TITLE
Add automatic Jira field lookup feature

### DIFF
--- a/collectors/feature/jira/docker/properties-builder.sh
+++ b/collectors/feature/jira/docker/properties-builder.sh
@@ -98,13 +98,20 @@ feature.masterStartDate=${JIRA_MASTER_START_DATE:-2008-01-01T00:00:00.000000}
 # Multiple comma-separated values can be specified.
 feature.jiraIssueTypeNames=${JIRA_ISSUE_TYPE_NAMES:-Story,Epic,Bug,Task,Sub-task}
 
+# Setting this to true will make this collector attempt to automatically look up the Sprint, Epic, Story Points, and Team
+# custom field IDs based on the "friendly" field names provided in jiraSprintDataFieldName, jiraEpicIdFieldName,
+# jiraStoryPointsFieldName, and jiraTeamFieldName.  If this doesn't work for some reason, you can set this to false,
+# and manually provide the custom field names (e.g. customfield_10002) in jiraSprintDataFieldName, jiraEpicIdFieldName,
+# jiraStoryPointsFieldName, and jiraTeamFieldName.
+feature.jiraLookupCustomFields=${JIRA_LOOKUP_CUSTOM_FIELDS:-true}
+
 # In Jira, your instance will have its own custom field created for "sprint" or "timebox" details,
 # which includes a list of information.  This field allows you to specify that data field for your
 # instance of Jira. Note: You can retrieve your instance's sprint data field name
 # via the following URI, and look for a package name com.atlassian.greenhopper.service.sprint.Sprint;
 # your custom field name describes the values in this field:
 # https://[your-jira-domain-name]/rest/api/2/issue/[some-issue-name]
-feature.jiraSprintDataFieldName=${JIRA_SPRINT_DATA_FIELD_NAME:-customfield_10007}
+feature.jiraSprintDataFieldName=${JIRA_SPRINT_DATA_FIELD_NAME:-Sprint}
 
 # In Jira, your instance will have its own custom field created for "super story" or "epic" back-end ID,
 # which includes a list of information.  This field allows you to specify that data field for your instance
@@ -112,7 +119,7 @@ feature.jiraSprintDataFieldName=${JIRA_SPRINT_DATA_FIELD_NAME:-customfield_10007
 # queried user story issue has a super issue (e.g., epic) tied to it; your custom field name describes the
 # epic value you expect to see, and is the only field that does this for a given issue:
 # https://[your-jira-domain-name]/rest/api/2/issue/[some-issue-name]
-feature.jiraEpicIdFieldName=${JIRA_EPIC_FIELD_NAME:-customfield_10400}
+feature.jiraEpicIdFieldName=${JIRA_EPIC_FIELD_NAME:-Epic Link}
 
 # In Jira, your instance will have its own custom field created for "story points"
 # This field allows you to specify that data field for your instance
@@ -120,7 +127,7 @@ feature.jiraEpicIdFieldName=${JIRA_EPIC_FIELD_NAME:-customfield_10400}
 # queried user story issue has story points set on it; your custom field name describes the
 # story points value you expect to see:
 # https://[your-jira-domain-name]/rest/api/2/issue/[some-issue-name]
-feature.jiraStoryPointsFieldName=${JIRA_STORY_POINTS_FIELD_NAME:-customfield_10002}
+feature.jiraStoryPointsFieldName=${JIRA_STORY_POINTS_FIELD_NAME:-Story Points}
 
 # In Jira, your instance will have its own custom field created for "team"
 # This field allows you to specify that data field for your instance
@@ -128,7 +135,7 @@ feature.jiraStoryPointsFieldName=${JIRA_STORY_POINTS_FIELD_NAME:-customfield_100
 # queried user story issue has team set on it; your custom field name describes the
 # team value you expect to see:
 # https://[your-jira-domain-name]/rest/api/2/issue/[some-issue-name]
-feature.jiraTeamFieldName=${JIRA_TEAM_FIELD_NAME}
+feature.jiraTeamFieldName=${JIRA_TEAM_FIELD_NAME:-Team}
 
 # Set this to true if you use boards as team
 feature.jiraBoardAsTeam=${JIRA_BOARD_AS_TEAM:-false}

--- a/collectors/feature/jira/src/main/java/com/capitalone/dashboard/collector/FeatureCollectorTask.java
+++ b/collectors/feature/jira/src/main/java/com/capitalone/dashboard/collector/FeatureCollectorTask.java
@@ -96,6 +96,7 @@ public class FeatureCollectorTask extends CollectorTask<FeatureCollector> {
         if (!MapUtils.isEmpty(issueTypeIds)){
             collector.getProperties().put("issueTypesMap", issueTypeIds);
         }
+        jiraClient.updateFieldNames();
         return collector;
     }
 

--- a/collectors/feature/jira/src/main/java/com/capitalone/dashboard/collector/FeatureSettings.java
+++ b/collectors/feature/jira/src/main/java/com/capitalone/dashboard/collector/FeatureSettings.java
@@ -43,8 +43,14 @@ public class FeatureSettings {
 	 * Multiple comma-separated values can be specified.
 	 */
 	private String[] jiraIssueTypeNames;
+        /**
+         * If this is set to true (default), this will make the collector automatically look up the "customfield" names for jiraSprintDataFieldName, jiraEpicIdFieldName, jiraStoryPointsFieldName, and jiraTeamFieldName.
+         * If this is false, you will need to provide the actually "customfield" names for those parameters.
+         */
+        private boolean jiraLookupCustomFields;
 	/**
-	 * In Jira, your instance will have its own custom field created for "sprint" or "timebox" details, which includes a list of information.  This field allows you to specify that data field for your instance of Jira.
+	 * In Jira, your instance will have its own custom field created for "sprint" or "timebox" details, which includes a list of information.  When jiraLookupCustomFields is set to true, specify the friendly name of this field (e.g. "Sprint", note that it is case-sensitive).
+         * If jiraLookupCustomFields is false, specify the data field name (e.g. "customfield_10100") for your instance of Jira.
 	 * <p>
 	 * </p>
 	 * <strong>Note:</strong> You can retrieve your instance's sprint data field name
@@ -53,34 +59,28 @@ public class FeatureSettings {
 	 */
 	private String jiraSprintDataFieldName;
 	/**
-	 * In Jira, your instance will have its own custom field created for "super story" or "epic" back-end ID, which includes a list of information.  This field allows you to specify that data field for your instance of Jira.
+	 * In Jira, your instance will have its own custom field created for "super story" or "epic" back-end ID, which includes a list of information.   When jiraLookupCustomFields is set to true, specify the friendly name of this field (e.g. "Epic", note that it is case-sensitive).
 	 * <p>
 	 * </p>
-     * <strong>Note:</strong> You can retrieve your instance's epic ID field name
+         * <strong>Note:</strong> You can retrieve your instance's epic ID field name
 	 * via the following URI where your queried user story issue has a super issue (e.g., epic) tied to it; your custom field name describes the epic value you expect to see, and is the only field that does this for a given issue:
 	 *  https://[your-jira-domain-name]/rest/api/2/issue/[some-issue-name]
 	 */
-
-    private String jiraEpicIdFieldName;
-
-    private String jiraStoryPointsFieldName;
-
+        private String jiraEpicIdFieldName;
+        private String jiraStoryPointsFieldName;
 	/**
 	 * Its a custom field in JIRA, set it here
 	 */
 	private String jiraTeamFieldName;
-
 	/**
 	 * If you want to select boards in the Hygieia UI
 	 */
 	private boolean jiraBoardAsTeam;
-
 	/**
 	 * Defines the maximum number of features allow per board. If limit is reach collection will not happen for given board
 	 */
 	@Value("${feature.maxNumberOfFeaturesPerBoard:2000}")
 	private int maxNumberOfFeaturesPerBoard;
-
 	/**
 	 *  Defines how to update features per board. If true then only update based on enabled collectorItems otherwise full update
 	 */
@@ -147,25 +147,29 @@ public class FeatureSettings {
 
 	public void setJiraIssueTypeNames(String[] jiraIssueTypeNames) { this.jiraIssueTypeNames = jiraIssueTypeNames; }
 
+	public boolean isJiraLookupCustomFields() { return jiraLookupCustomFields; }
+
+	public void setJiraLookupCustomFields(boolean jiraLookupCustomFields) { this.jiraLookupCustomFields = jiraLookupCustomFields; }
+
 	public String getJiraSprintDataFieldName() { return jiraSprintDataFieldName; }
 
 	public void setJiraSprintDataFieldName(String jiraSprintDataFieldName) { this.jiraSprintDataFieldName = jiraSprintDataFieldName; }
 
-    public String getJiraEpicIdFieldName() { return jiraEpicIdFieldName; }
+        public String getJiraEpicIdFieldName() { return jiraEpicIdFieldName; }
 
-    public void setJiraEpicIdFieldName(String jiraEpicIdFieldName) { this.jiraEpicIdFieldName = jiraEpicIdFieldName; }
+        public void setJiraEpicIdFieldName(String jiraEpicIdFieldName) { this.jiraEpicIdFieldName = jiraEpicIdFieldName; }
 
-    public String getJiraStoryPointsFieldName() { return jiraStoryPointsFieldName; }
+        public String getJiraStoryPointsFieldName() { return jiraStoryPointsFieldName; }
 
-    public void setJiraStoryPointsFieldName(String jiraStoryPointsFieldName) { this.jiraStoryPointsFieldName = jiraStoryPointsFieldName; }
+        public void setJiraStoryPointsFieldName(String jiraStoryPointsFieldName) { this.jiraStoryPointsFieldName = jiraStoryPointsFieldName; }
 
-    public String getJiraTeamFieldName() { return jiraTeamFieldName; }
+        public String getJiraTeamFieldName() { return jiraTeamFieldName; }
 
-    public void setJiraTeamFieldName(String jiraTeamFieldName) { this.jiraTeamFieldName = jiraTeamFieldName; }
+        public void setJiraTeamFieldName(String jiraTeamFieldName) { this.jiraTeamFieldName = jiraTeamFieldName; }
 
-    public int getRefreshTeamAndProjectHours() { return refreshTeamAndProjectHours; }
+        public int getRefreshTeamAndProjectHours() { return refreshTeamAndProjectHours; }
 
-    public void setRefreshTeamAndProjectHours(int refreshTeamAndProjectHours) { this.refreshTeamAndProjectHours = refreshTeamAndProjectHours; }
+        public void setRefreshTeamAndProjectHours(int refreshTeamAndProjectHours) { this.refreshTeamAndProjectHours = refreshTeamAndProjectHours; }
 
 	public boolean isJiraBoardAsTeam() { return jiraBoardAsTeam; }
 

--- a/collectors/feature/jira/src/main/java/com/capitalone/dashboard/collector/JiraClient.java
+++ b/collectors/feature/jira/src/main/java/com/capitalone/dashboard/collector/JiraClient.java
@@ -27,4 +27,8 @@ public interface JiraClient {
 	List<String> getAllIssueIds(String id, JiraMode mode);
 
 	Map<String, String> getJiraIssueTypeIds();
+
+        void updateFieldNames();
+
+	Map<String, String> lookupCustomFields();
 }


### PR DESCRIPTION
This closes #3037 by adding a new feature (enabled by default) that will attempt to look up the `customfield` names from Jira based on "friendly" names (e.g. Sprint, Epic, Story Points).

Still a work in progress:
- [x] Validate and test out different custom fields
- [ ] Add tests
- [ ] Update documentation