### PR TITLE
Fix the issues with user logins

### DIFF
--- a/UI/src/app/dashboard/services/authInterceptor.js
+++ b/UI/src/app/dashboard/services/authInterceptor.js
@@ -12,7 +12,7 @@
     function authInterceptor($q, $location, tokenService) {
       return {
         responseError: function (response) {
-          if (response.status === 401 || response.status === 500) {
+          if (response.status === 401 || response.status === 403) {
             tokenService.removeToken();
             $location.path('/login');
           }


### PR DESCRIPTION
Users are forced to login page when api throws 500 errors. Fixing so that they are redirected to login page only when they see 401 or 403.