### PR TITLE
only create fonts from awesome-font

### DIFF
--- a/UI/gulpfile.js
+++ b/UI/gulpfile.js
@@ -237,7 +237,7 @@ gulp.task('views', function() {
 gulp.task('fonts', function() {
     return gulp
         .src([
-            'node_modules/**/*'
+            'node_modules/components-font-awesome/**/*',
         ])
         .pipe(filter('**/*.{eot,ttf,woff,woff2}'))
         .pipe(flatten())


### PR DESCRIPTION
so we're not searching all node modules for all fonts. This really increases build speed.

Raised this in isolation to #3142 in case that PR is too large.

Address: #3144 