### PR TITLE
Fix pull request count for repo widget

### DIFF
--- a/UI/src/components/widgets/repo/view.js
+++ b/UI/src/components/widgets/repo/view.js
@@ -294,14 +294,14 @@
                         lastDayPullContributors.push(pull.userId);
                     }
                 }
-                else if(pull.timestamp >= sevenDays.getTime()) {
+                if(pull.timestamp >= sevenDays.getTime()) {
                     lastsevenDayPullCount++;
 
                     if(lastsevenDaysPullContributors.indexOf(pull.userId) == -1) {
                         lastsevenDaysPullContributors.push(pull.userId);
                     }
                 }
-                else if(pull.timestamp >= fourteenDays.getTime()) {
+                if(pull.timestamp >= fourteenDays.getTime()) {
                     lastfourteenDayPullCount++;
                     ctrl.pulls.push(pull);
                     if(lastfourteenDaysPullContributors.indexOf(pull.userId) == -1) {
@@ -397,14 +397,14 @@
                         lastDayIssueContributors.push(issue.userId);
                     }
                 }
-                else if(issue.timestamp >= sevenDays.getTime()) {
+                if(issue.timestamp >= sevenDays.getTime()) {
                     lastsevenDayIssueCount++;
 
                     if(lastsevenDaysIssueContributors.indexOf(issue.userId) == -1) {
                         lastsevenDaysIssueContributors.push(issue.userId);
                     }
                 }
-                else if(issue.timestamp >= fourteenDays.getTime()) {
+                if(issue.timestamp >= fourteenDays.getTime()) {
                     lastfourteenDayIssueCount++;
                     ctrl.issues.push(issue);
                     if(lastfourteenDaysIssueContributors.indexOf(issue.userId) == -1) {


### PR DESCRIPTION
Fix pull request count for a day, seven day and fourteen days. A pull request count should be aggregated.
resolves : https://github.com/Hygieia/Hygieia/issues/3181

The logic for commits count in repo widget is correct but it is incorrect for PR and issues -
https://github.com/Hygieia/Hygieia/blob/8f14d527dfba42fae5abe65a17224754b887d4e6/UI/src/components/widgets/repo/view.js#L184-L207

If an issue is included in 7 days count then it should be included in 14 days count as well. So `else if` block should be replaced with `if` block,
https://github.com/Hygieia/Hygieia/blob/master/UI/src/components/widgets/repo/view.js#L297-L312

This PR fixes this issue by changing `else if` to `if` block.