### PR TITLE
Sonar documentation changes for usernames/passwords

### DIFF
--- a/pages/hygieia/collectors/build/sonar.md
+++ b/pages/hygieia/collectors/build/sonar.md
@@ -97,11 +97,7 @@ The sample `application.properties` file lists parameters with sample values to 
 		sonar.metrics[0]=ncloc,violations,new_vulnerabilities,critical_violations,major_violations,blocker_violations,tests,test_success_density,test_errors,test_failures,coverage,line_coverage,sqale_index,alert_status,quality_gate_details
 		
 		# Sonar login credentials
-                # username1, username2, username3, etc.
-		sonar.usernames= 
-                # password1, password2, password3, etc.       
-                sonar.passwords=
-
-
+                sonar.usernames= # format: username1, username2, username3, etc.
+                sonar.passwords= # format: password1, password2, password3, etc.
 
 ```

--- a/pages/hygieia/collectors/build/sonar.md
+++ b/pages/hygieia/collectors/build/sonar.md
@@ -97,7 +97,7 @@ The sample `application.properties` file lists parameters with sample values to 
 		sonar.metrics[0]=ncloc,violations,new_vulnerabilities,critical_violations,major_violations,blocker_violations,tests,test_success_density,test_errors,test_failures,coverage,line_coverage,sqale_index,alert_status,quality_gate_details
 		
 		# Sonar login credentials
-		sonar.username=
-        sonar.password=
+		sonar.usernames=
+        sonar.passwords=
 
 ```

--- a/pages/hygieia/collectors/build/sonar.md
+++ b/pages/hygieia/collectors/build/sonar.md
@@ -97,9 +97,11 @@ The sample `application.properties` file lists parameters with sample values to 
 		sonar.metrics[0]=ncloc,violations,new_vulnerabilities,critical_violations,major_violations,blocker_violations,tests,test_success_density,test_errors,test_failures,coverage,line_coverage,sqale_index,alert_status,quality_gate_details
 		
 		# Sonar login credentials
-        # username1, username2, username3, etc.
+                # username1, username2, username3, etc.
 		sonar.usernames= 
-        # password1, password2, password3, etc.
-        sonar.passwords=
+                # password1, password2, password3, etc.       
+                sonar.passwords=
+
+
 
 ```

--- a/pages/hygieia/collectors/build/sonar.md
+++ b/pages/hygieia/collectors/build/sonar.md
@@ -97,7 +97,9 @@ The sample `application.properties` file lists parameters with sample values to 
 		sonar.metrics[0]=ncloc,violations,new_vulnerabilities,critical_violations,major_violations,blocker_violations,tests,test_success_density,test_errors,test_failures,coverage,line_coverage,sqale_index,alert_status,quality_gate_details
 		
 		# Sonar login credentials
-		sonar.usernames=
+        # username1, username2, username3, etc.
+		sonar.usernames= 
+        # password1, password2, password3, etc.
         sonar.passwords=
 
 ```


### PR DESCRIPTION
Changes with indentation for sonar username/passwords. Comments on format of the credentials.