### PR TITLE
Documentation upgrades to link directly to github pages.  

### DIFF
--- a/_data/sidebars/hygieia_sidebar.yml
+++ b/_data/sidebars/hygieia_sidebar.yml
@@ -26,6 +26,19 @@ entries:
       output: web, pdf
       type: homepage
 
+  - title: Components
+    output: web, pdf
+    folderitems:
+      - title: API
+        url: https://github.com/Hygieia/Hygieia/blob/gh-pages/pages/hygieia/api/api.md
+        output: web, pdf
+      - title: Audit API
+          url: https://github.com/Hygieia/Hygieia/blob/gh-pages/pages/hygieia/api-audit/api-audit.md
+          output: web, pdf
+      - title: Collectors' Configuration
+        url: /collectors.html
+        output: web, pdf
+
   - title: Installing the New Hygieia UI
     output: web, pdf
     folderitems:
@@ -42,36 +55,22 @@ entries:
     - title: Database
       url: /database.html
       output: web, pdf
-    - title: API
-      url: /api.html
-      output: web, pdf
-    - title: Audit API
-      url: /api-audit.html
-      output: web, pdf
     - title: UI
-      url: /ui.html
+      url: https://github.com/Hygieia/Hygieia/blob/gh-pages/pages/hygieia/UI/ui.md
       output: web, pdf
 
   - title: Configuration
     output: web, pdf
     folderitems:
-    - title: Collectors' Configuration
-      url: /collectors.html
+    - title: Hygieia-Jenkins Plugin
+      url: https://github.com/Hygieia/Hygieia/blob/gh-pages/pages/hygieia/hygieia-jenkins-plugin/hygieia-jenkins-plugin.md
       output: web, pdf
-
-      subfolders:
-      - title: Additional Configuration
-        output: web, pdf
-        subfolderitems:
-           - title: Hygieia-Jenkins Plugin
-             url: /hygieia-jenkins-plugin.html
-             output: web, pdf
-           - title: GitHub Webhook
-             url: /webhook.html
-             output: web, pdf
-           - title: Proxy Authentication
-             url: /proxyauthentication.html
-             output: web, pdf
+    - title: GitHub Webhook
+      url: https://github.com/Hygieia/Hygieia/blob/gh-pages/pages/hygieia/webhook.md
+      output: web, pdf
+    - title: Proxy Authentication
+      url: https://github.com/Hygieia/Hygieia/blob/gh-pages/pages/hygieia/proxyauthentication.md
+      output: web, pdf
 
   - title: Building Docker Image
     output: web, pdf

--- a/_data/sidebars/hygieia_sidebar.yml
+++ b/_data/sidebars/hygieia_sidebar.yml
@@ -33,8 +33,8 @@ entries:
         url: https://github.com/Hygieia/Hygieia/blob/gh-pages/pages/hygieia/api/api.md
         output: web, pdf
       - title: Audit API
-          url: https://github.com/Hygieia/Hygieia/blob/gh-pages/pages/hygieia/api-audit/api-audit.md
-          output: web, pdf
+        url: https://github.com/Hygieia/Hygieia/blob/gh-pages/pages/hygieia/api-audit/api-audit.md
+        output: web, pdf
       - title: Collectors' Configuration
         url: /collectors.html
         output: web, pdf

--- a/pages/hygieia/api/api.md
+++ b/pages/hygieia/api/api.md
@@ -13,7 +13,7 @@ permalink: api.html
 
 Hygieia API layer contains all the typical REST API services that work with the source system data (collected by service tasks). The Hygieia API layer is an abstraction of the local and source system data layer. All API REST controllers are generic to their purpose - they are not specific to any given source system.
 
-For detailed information on APIs, see the Swagger documentation available at `http://[your-doman].com/api/swagger/index.html#`.
+For detailed information on APIs, see the Swagger documentation available at `http://[your-domain].com/api/swagger/index.html#`.
 
 Hygieia uses Spring Boot to package the API as an executable JAR file with dependencies.
 

--- a/pages/hygieia/collectors/collectors.md
+++ b/pages/hygieia/collectors/collectors.md
@@ -24,38 +24,39 @@ You may choose the collectors applicable to your DevOps toolset from the list of
 Hygieia supports the following collectors Inventory:
 
 - **Build Collectors**
-  - [Bamboo](build/bamboo.md)
-  - [Jenkins](build/jenkins.md)
-  - [Jenkins-codequality](build/jenkins-codequality.md)
-  - [Jenkins Cucumber](build/jenkins-cucumber.md)
-  - [Sonar](build/sonar.md)
+  - [Bamboo](https://github.com/Hygieia/Hygieia/blob/gh-pages/pages/hygieia/collectors/build/bamboo.md)
+  - [Jenkins](https://github.com/Hygieia/Hygieia/blob/gh-pages/pages/hygieia/collectors/build/jenkins.md)
+  - [Jenkins-codequality](https://github.com/Hygieia/Hygieia/blob/gh-pages/pages/hygieia/collectors/build/jenkins-codequality.md)
+  - [Jenkins Cucumber](https://github.com/Hygieia/Hygieia/blob/gh-pages/pages/hygieia/collectors/build/jenkins-cucumber.md)
+  - [Sonar](https://github.com/Hygieia/Hygieia/blob/gh-pages/pages/hygieia/collectors/build/sonar.md)
 - **Cloud Collectors**
-  - [AWS](cloud/aws.md)
+  - [AWS](https://github.com/Hygieia/Hygieia/blob/gh-pages/pages/hygieia/collectors/cloud/aws.md)
 - **Deploy Collectors**
-  - [uDeploy](deploy/udeploy.md)
-  - [XLDeploy](deploy/xldeploy.md)
+  - [uDeploy](https://github.com/Hygieia/Hygieia/blob/gh-pages/pages/hygieia/collectors/deploy/udeploy.md)
+  - [XLDeploy](https://github.com/Hygieia/Hygieia/blob/gh-pages/pages/hygieia/collectors/deploy/xldeploy.md)
 - **Feature Collectors**
-  - [Jira](feature/jira.md)
-  - [VersionOne](feature/versionone.md)
-  - [Gitlab](feature/feature-gitlab.md)
-  - [Rally](feature/rally.md)
+  - [Jira](https://github.com/Hygieia/Hygieia/blob/gh-pages/pages/hygieia/collectors/feature/jira.md)
+  - [VersionOne](https://github.com/Hygieia/Hygieia/blob/gh-pages/pages/hygieia/collectors/feature/versionone.md)
+  - [Gitlab](https://github.com/Hygieia/Hygieia/blob/gh-pages/pages/hygieia/collectors/feature/feature-gitlab.md)
+  - [Rally](https://github.com/Hygieia/Hygieia/blob/gh-pages/pages/hygieia/collectors/feature/rally.md)
 - **Miscellaneous Collectors**
-  - [Chat Ops](misc/chat-ops.md)
-  - [Score](misc/score.md)
+  - [Chat Ops](https://github.com/Hygieia/Hygieia/blob/gh-pages/pages/hygieia/collectors/misc/chat-ops.md)
+  - [Score](https://github.com/Hygieia/Hygieia/blob/gh-pages/pages/hygieia/collectors/misc/score.md)
 - **SCM Collectors** 
-  - [Bitbucket](scm/bitbucket.md)
-  - [GitHub](scm/github.md)
-  - [Gitlab](scm/gitlab.md)
-  - [Subversion](scm/subversion.md)
-  - [GitHub GraphQL](scm/github-graphql.md)
+  - [Bitbucket](https://github.com/Hygieia/Hygieia/blob/gh-pages/pages/hygieia/collectors/scm/bitbucket.md)
+  - [GitHub](https://github.com/Hygieia/Hygieia/blob/gh-pages/pages/hygieia/collectors/scm/github.md)
+  - [Gitlab](https://github.com/Hygieia/Hygieia/blob/gh-pages/pages/hygieia/collectors/scm/gitlab.md)
+  - [Subversion](https://github.com/Hygieia/Hygieia/blob/gh-pages/pages/hygieia/collectors/scm/subversion.md)
+  - GitHub GraphQL - Currently Unavailable
 - **Performance Collector**
-  - [AppDynamics](performance/appdynamics.md)
+  - [AppDynamics](https://github.com/Hygieia/Hygieia/blob/gh-pages/pages/hygieia/collectors/performance/appdynamics.md)
 - **Configuration Management Database (CMDB)**
-  - [HP Service Manager (HPSM)](cmdb/hpsm.md)
+  - [HP Service Manager (HPSM)](https://github.com/Hygieia/Hygieia/blob/gh-pages/pages/hygieia/collectors/cmdb/hpsm.md)
 - **Library Policy**
-  - [Nexus IQ](library-policy/nexus-iq-collector.md)
+  - [Nexus IQ](https://github.com/Hygieia/Hygieia/blob/gh-pages/pages/hygieia/collectors/library-policy/nexus-iq-collector.md)
+  - [WhiteSource](https://github.com/Hygieia/Hygieia/blob/gh-pages/pages/hygieia/collectors/library-policy/whitesource.md)
 - **Artifact Repository**
-  - [Artifactory](artifact/artifactory.md)
+  - [Artifactory](https://github.com/Hygieia/Hygieia/blob/gh-pages/pages/hygieia/collectors/artifact/artifactory.md)
 
 ## Encrypted Properties
 

--- a/pages/hygieia/newUI.md
+++ b/pages/hygieia/newUI.md
@@ -10,9 +10,9 @@ folder: hygieia
 ---
 ## What changes have we made to the UI? 
 
-We are currently upgrading from our old UI (using AngularJS) to a new UI, which will use Angular 8 and node 12.
+We have upgraded from our old UI (using AngularJS) to a new UI, which uses Angular 8 and node 12.
 
-This upgrade will give us a chance to clean up code, fix existing bugs, and modernize the user interface. With the same api, users will be able to take advantage of Hygieia's data from a different perspective with new charts, visualization tools, and UI features.
+This upgrade gave us a chance to clean up code, fix existing bugs, and modernize the user interface. With the same api, users will be able to take advantage of Hygieia's data from a different perspective with new charts, visualization tools, and UI features.
 
 ## Download or Clone new Hygieia UI 
 

--- a/pages/hygieia/newUI.md
+++ b/pages/hygieia/newUI.md
@@ -10,9 +10,9 @@ folder: hygieia
 ---
 ## What changes have we made to the UI? 
 
-We have upgraded from our old UI (using AngularJS) to a new UI, which uses Angular 8 and node 12.
+We have upgraded our old UI (using AngularJS) to a new UI, which uses Angular 8 and node 12.
 
-This upgrade gave us a chance to clean up code, fix existing bugs, and modernize the user interface. With the same api, users will be able to take advantage of Hygieia's data from a different perspective with new charts, visualization tools, and UI features.
+This upgrade cleans up code, fixes existing bugs, and modernizes the user interface. With the same api, users will be able to take advantage of Hygieia's data from a different perspective with new charts, visualization tools, and UI features.
 
 ## Download or Clone new Hygieia UI 
 


### PR DESCRIPTION
Documentation refresh for instruction guide. 

Switched around sidebar and created direct links to the github readme pages.  Collectors, API and Audit API are in the same category under Components. 